### PR TITLE
Fixed matplotlib version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy<1.12 ; python_version >= '3.2' and python_version < '3.4' # numpy starting from 1.12 doesn't support python 3.2 and 3.3
 numpy ; python_version < '3.0' or python_version >= '3.4' # newest numpy for py 2.7, 3.4 and higher
 # matplotlib starting from 2.0, doesn't work well, see issue #226 and others
-matplotlib<=1.5.1 
+matplotlib<=1.5.3 
 pydicom
 scipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,5 @@
 numpy<1.12 ; python_version >= '3.2' and python_version < '3.4' # numpy starting from 1.12 doesn't support python 3.2 and 3.3
 numpy ; python_version < '3.0' or python_version >= '3.4' # newest numpy for py 2.7, 3.4 and higher
-# matplotlib starting from 2.0, doesn't work well with Python 3.2 and 3.3 and Windows
-matplotlib<=1.5.1 ; (python_version >= '3.2' and python_version < '3.4') or os_name == 'nt' # py 3.2 and 3.3 and Windows
-matplotlib<=2.0.0 ; (python_version < '3.0' or python_version >= '3.4') and os_name != 'nt' # py 2.7 , 3.4 and higher and not Windows
-pydicom
+# matplotlib starting from 2.0, doesn't work well, see issue #226 and others
+matplotlib<=1.5.1 pydicom
 scipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ numpy<1.12 ; python_version >= '3.2' and python_version < '3.4' # numpy starting
 numpy ; python_version < '3.0' or python_version >= '3.4' # newest numpy for py 2.7, 3.4 and higher
 # matplotlib starting from 2.0, doesn't work well with Python 3.2 and 3.3 and Windows
 matplotlib<=1.5.1 ; (python_version >= '3.2' and python_version < '3.4') or os_name == 'nt' # py 3.2 and 3.3 and Windows
-matplotlib ; (python_version < '3.0' or python_version >= '3.4') and os_name != 'nt' # py 2.7 , 3.4 and higher and not Windows
+matplotlib<=2.0.0 ; (python_version < '3.0' or python_version >= '3.4') and os_name != 'nt' # py 2.7 , 3.4 and higher and not Windows
 pydicom
 scipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 numpy<1.12 ; python_version >= '3.2' and python_version < '3.4' # numpy starting from 1.12 doesn't support python 3.2 and 3.3
 numpy ; python_version < '3.0' or python_version >= '3.4' # newest numpy for py 2.7, 3.4 and higher
 # matplotlib starting from 2.0, doesn't work well, see issue #226 and others
-matplotlib<=1.5.1 pydicom
+matplotlib<=1.5.1 
+pydicom
 scipy

--- a/setup.py
+++ b/setup.py
@@ -185,7 +185,7 @@ setuptools.setup(
     ],
     package_data={'pytrip': ['data/*.dat', 'pytriplib.*']},
     install_requires=[
-        'matplotlib', 'numpy', 'pydicom', 'scipy'
+        'matplotlib<=1.5.3', 'numpy', 'pydicom', 'scipy'
     ],
     include_dirs=[np.get_include()],
     ext_modules=extensions,


### PR DESCRIPTION
It looks that 32bit version is missing since 2.0.0-1

Fixes #226 