### PR TITLE
create proper empty cubes which can be written to dicom

### DIFF
--- a/pytrip/cube.py
+++ b/pytrip/cube.py
@@ -277,7 +277,7 @@ class Cube(object):
         :param int dimz: number of voxels along z
         :param float pixel_size: size of each pixel (x == y) in [mm]
         :param float slice_distance: the distance between two slices (z) in [mm]
-        :param float slice_offset: star position of the first slice in [mm] (default 0.0 mm)
+        :param float slice_offset: start position of the first slice in [mm] (default 0.0 mm)
         """
         self.dimx = dimx
         self.dimy = dimy
@@ -285,14 +285,12 @@ class Cube(object):
         self.slice_number = dimz
         self.pixel_size = pixel_size
         self.slice_distance = slice_distance
-        self.cube = np.ones((dimz, dimy, dimx), dtype=np.int16) * (value)
+        self.cube = np.ones((dimz, dimy, dimx), dtype=np.int16) * value
         self.slice_dimension = dimx
         self.num_bytes = 2
         self.data_type = "integer"
         self.pydata_type = np.int16
-        self.slice_pos = []
-        for _i, i in enumerate(range(dimz)):
-            self.slice_pos.append(slice_distance * i + slice_offset)
+        self.slice_pos = [slice_distance * i + slice_offset for i in range(dimz)]
         self.header_set = True
 
     def override_cube_values(self, voi, value):

--- a/pytrip/cube.py
+++ b/pytrip/cube.py
@@ -266,7 +266,7 @@ class Cube(object):
                                 data[i_z][i_y][i_x] = preset
         self.cube = data
 
-    def create_empty_cube(self, value, dimx, dimy, dimz, pixel_size, slice_distance):
+    def create_empty_cube(self, value, dimx, dimy, dimz, pixel_size, slice_distance, slice_offset=0.0):
         """ Creates an empty Cube object.
 
         Values are stored as 2-byte integers.
@@ -277,6 +277,7 @@ class Cube(object):
         :param int dimz: number of voxels along z
         :param float pixel_size: size of each pixel (x == y) in [mm]
         :param float slice_distance: the distance between two slices (z) in [mm]
+        :param float slice_offset: star position of the first slice in [mm] (default 0.0 mm)
         """
         self.dimx = dimx
         self.dimy = dimy
@@ -289,6 +290,10 @@ class Cube(object):
         self.num_bytes = 2
         self.data_type = "integer"
         self.pydata_type = np.int16
+        self.slice_pos = []
+        for _i, i in enumerate(range(dimz)):
+            self.slice_pos.append(slice_distance * i + slice_offset)
+        self.header_set = True
 
     def override_cube_values(self, voi, value):
         """ Overwrites the Cube voxels within the given Voi with 'value'.


### PR DESCRIPTION
Closes #78 

```
$ mkdir aa
$ cat bug.py
import pytrip as pt

c = pt.CtxCube()
c.create_empty_cube(
    value=-1024,
    dimx=10,
    dimy=10,
    dimz=30,
    pixel_size=1,
    slice_distance=1.22)
c.write("tmp")
c.write_dicom("aa") 
```