### PR TITLE
Enable slice mapping for non-equidistant slices

### DIFF
--- a/pytrip/cube.py
+++ b/pytrip/cube.py
@@ -351,7 +351,7 @@ class Cube(object):
         if self.z_table:
             output_str += "z_table yes\n"
             output_str += "slice_no  position  thickness  gantry_tilt\n"
-            for i, item enumerate(self.slice_pos):
+            for i, item in enumerate(self.slice_pos):
                 output_str += "{:3d}{:16.4f}{:13.4f}{:14.4f}\n".format(i + 1, item,
                                                                        self.slice_distance, 0)  # 0 gantry tilt
         else:

--- a/pytrip/cube.py
+++ b/pytrip/cube.py
@@ -194,9 +194,9 @@ class Cube(object):
         :params int idx: index number of slice (no bound check)
         :returns: position of slice in [mm] including offset
         """
-        # TODO: out of bounds, return nearest neighbour. Update docstring.
-        # return idx * self.slice_distance + self.zoffset
-        return self.slice_pos[idx] + self.zoffset
+        print(idx)
+        # note that self.slice_pos contains an array of positions including any zoffset.
+        return self.slice_pos[int(idx)]
 
     def create_cube_from_equation(self, equation, center, limits, radial=True):
         """ Create Cube from a given equation.
@@ -648,7 +648,15 @@ class Cube(object):
                     self.slice_pos[j] = float(content[i].split()[1])
                     i += 1
             i += 1
+
+        # zoffset from TRiP contains the integer amount of slice thicknesses as offset.
+        # Here we convert to an acutual offset in mm, which is stored in self.
         self.zoffset *= self.slice_distance
+
+        # generate slice position tables, if absent in header file
+        # Note:
+        # - ztable in .hed is _without_ offset
+        # - self.slice_pos however holds values _including_ offset.
         if has_ztable is not True:
             self.slice_pos = [float(j) for j in range(self.slice_number)]
             for i in range(self.slice_number):

--- a/pytrip/cube.py
+++ b/pytrip/cube.py
@@ -188,15 +188,14 @@ class Cube(object):
                indices[2] * self.slice_distance + self.zoffset]
         return pos
 
-    def slice_to_z(self, idx):
+    def slice_to_z(self, slice_number):
         """ Return z-position in [mm] of slice with index idx.
 
-        :params int idx: index number of slice (no bound check)
+        :params int slice_number: slice number, starting at 1 and no bound check done here.
         :returns: position of slice in [mm] including offset
         """
-        print(idx)
         # note that self.slice_pos contains an array of positions including any zoffset.
-        return self.slice_pos[int(idx)]
+        return self.slice_pos[int(slice_number) - 1]
 
     def create_cube_from_equation(self, equation, center, limits, radial=True):
         """ Create Cube from a given equation.
@@ -349,15 +348,17 @@ class Cube(object):
         # """output_str += "zoffset " +
         # str(int(round(self.zoffset/self.slice_distance))) + "\n" """
         output_str += "dimz " + str(self.dimz) + "\n"
-        output_str += "z_table no\n"
+        if self.z_table:
+            output_str += "z_table yes\n"
+            output_str += "slice_no  position  thickness  gantry_tilt\n"
+            for i in range(len(self.slice_pos)):
+                output_str += "{:3d}{:16.4f}{:13.4f}{:14.4f}\n".format(i + 1,
+                                                                       self.slice_pos[i],
+                                                                       self.slice_distance,
+                                                                       0)  # gantry tilt
+        else:
+            output_str += "z_table no\n"
 
-        # """if self.z_table is True:
-        #     output_str += "z_table yes\n"
-        #     output_str += "slice_no  position  thickness  gantry_tilt\n"
-        #     for i in range(len(self.slice_pos)):
-        #         output_str +=
-        # "  %d\t%.4f\t%.4f\t%.4f\n"%(i+1,self.slice_pos[i],
-        # self.slice_distance,0)"""
         with open(path, "w+") as f:
             f.write(output_str)
 

--- a/pytrip/cube.py
+++ b/pytrip/cube.py
@@ -860,4 +860,3 @@ class Cube(object):
             cube = cube.byteswap()
         cube.tofile(path)
         return
-

--- a/pytrip/cube.py
+++ b/pytrip/cube.py
@@ -191,41 +191,12 @@ class Cube(object):
     def slice_to_z(self, idx):
         """ Return z-position in [mm] of slice with index idx.
 
-        :params int idx: index number of slice
-        :returns: position of slice in [mm]
+        :params int idx: index number of slice (no bound check)
+        :returns: position of slice in [mm] including offset
         """
         # TODO: out of bounds, return nearest neighbour. Update docstring.
-        return idx * self.slice_distance + self.zoffset
-
-    def pos_to_indices(self, pos):
-        """ Translate a real x,y,z position in [mm] to voxel indices, including any offets.
-
-        The z position is always following the slice positions.
-
-        :params indices: tuple or list of float positions (x,y,z) or [x,y,z]
-        :returns: list of positions,including offsets, as a list of floats [x,y,z]
-        """
-        indices = [int(pos[0] / self.pixel_size - self.xoffset / self.pixel_size),
-                   int(pos[1] / self.pixel_size - self.yoffset / self.pixel_size),
-                   int(pos[2] / self.slice_distance - self.zoffset / self.slice_distance)]
-        return indices  # TODO: out of bounds, return nearest neighbour. Update docstring.
-
-    def get_value_at_indice(self, idx):  # TODO: indice -> index (indece is wrong grammar)
-        """ Retrieves the value of a voxel at index [i,j,k].
-
-        :param [int*3] idx: list of integers descibing the i,j,k of the data cube.
-        :returns: The voxel value at index[i,j,k]
-        """
-        # TODO: out of bounds, throw error.
-        return self.cube[idx[2]][idx[1]][idx[0]]
-
-    def get_value_at_pos(self, pos):
-        """ Retrieves the value of a voxel at postion [x,y,z] in [mm], including any offsets.
-
-        :param [int*3] idx: list of integers descibing the i,j,k of the data cube.
-        :returns: The voxel value at index[i,j,k]
-        """
-        return self.get_value_at_indice(self.pos_to_indices(pos))
+        # return idx * self.slice_distance + self.zoffset
+        return self.slice_pos[idx] + self.zoffset
 
     def create_cube_from_equation(self, equation, center, limits, radial=True):
         """ Create Cube from a given equation.

--- a/pytrip/util.py
+++ b/pytrip/util.py
@@ -43,10 +43,3 @@ def evaluator(funct, name='funct'):
 
     f.__name__ = name
     return f
-
-def find_nearest(array, value):
-    idx = (np.abs(array - value)).argmin()
-    return array[idx]
-
-def float_compare(a, b, eps):
-    return abs(a - b) < eps

--- a/pytrip/util.py
+++ b/pytrip/util.py
@@ -43,3 +43,10 @@ def evaluator(funct, name='funct'):
 
     f.__name__ = name
     return f
+
+def find_nearest(array, value):
+    idx = (np.abs(array - value)).argmin()
+    return array[idx]
+
+def float_compare(a, b, eps):
+    return abs(a - b) < eps

--- a/pytrip/utils/cubeslice.py
+++ b/pytrip/utils/cubeslice.py
@@ -256,7 +256,7 @@ def main(args=sys.argv[1:]):
 
         slice_str = "Slice #: {:3d}/{:3d}\nSlice position: {:6.2f} mm".format(slice_id,
                                                                               cube.dimz,
-                                                                              cube.slice_to_z(slice_id - 1))
+                                                                              cube.slice_to_z(slice_id))
         text_slice.set_text(slice_str)
 
         if ct_cube is not None:

--- a/pytrip/vdx.py
+++ b/pytrip/vdx.py
@@ -1110,8 +1110,8 @@ class Slice:
             # and select DICOM object for current slice based on slice position
             # it is time consuming as for each call of this method we generate full DICOM representation (improve!)
 
-            
-            candidates = [dcm for dcm in self.cube.create_dicom() if np.isclose(dcm.SliceLocation,                                                                                   self.get_position())]
+            candidates = [dcm for dcm in self.cube.create_dicom() if np.isclose(dcm.SliceLocation,
+                                                                                self.get_position())]
             if len(candidates) > 0:
                 # finally we extract CT slice SOP Instance UID
                 ref_sop_instance_uid = candidates[0].SOPInstanceUID

--- a/pytrip/vdx.py
+++ b/pytrip/vdx.py
@@ -664,7 +664,7 @@ class Voi:
             points1.extend(reversed(points2))
             points1.append(points1[0])
             s = Slice(cube=self.cube)
-            s.add_contour(Contour(points1), cube=self.cube)
+            s.add_contour(Contour(points1, cube=self.cube))
         return s
 
     def define_colors(self):

--- a/pytrip/vdx.py
+++ b/pytrip/vdx.py
@@ -730,13 +730,14 @@ class Voi:
         return roi
 
     def create_dicom_contour_data(self, i):
-        """ Based on self.slices, Dicom conours are generated for the Dicom ROI.
+        """ Based on self.slices, DICOM contours are generated for the DICOM ROI.
 
         :returns: Dicom ROI_CONTOURS
         """
         roi_contours = Dataset()
         contours = []
         for slice in self.slices.values():
+            logger.info("Get contours from slice at {:10.3f} mm".format(slice.get_position()))
             contours.extend(slice.create_dicom_contours())
         roi_contours.Contours = Sequence(contours)
         roi_contours.ROIDisplayColor = self.get_color(i)
@@ -1006,7 +1007,6 @@ class Slice:
         """
         if len(self.contour) == 0:
             return None
-        # print("NBget_position:",self.contour[0].contour[0][2])
         return self.contour[0].contour[0][2]
 
     def get_intersections(self, pos):
@@ -1113,16 +1113,6 @@ class Slice:
 
             _eps = 0.00001
             
-            _found = False
-            for _dcm in self.cube.create_dicom():
-                print("NBNB:", _dcm.SliceLocation, self.get_position())
-                if float_compare(_dcm.SliceLocation, self.get_position(), _eps):
-                    print("<<<<<<<<<< FOUND")
-                    _found = True
-            if not _found:
-                print("oops")
-                exit()
-
             candidates = [dcm for dcm in self.cube.create_dicom() if float_compare(dcm.SliceLocation,
                                                                                    self.get_position(),
                                                                                    _eps)]

--- a/pytrip/vdx.py
+++ b/pytrip/vdx.py
@@ -767,7 +767,7 @@ class Voi:
                     for cont1 in s.contour:
                         for cont2 in cont1.contour:
                             # cont2[2] holds slice number (starting in 1), translate it to absolute position in [mm]
-                            cont2[2] = self.cube.slice_to_z(cont2[2])
+                            cont2[2] = self.cube.slice_to_z(int(cont2[2]))
                 if s.get_position() is None:
                     raise Exception("cannot calculate slice position")
                 # TODO investigate why 100 multiplier is needed

--- a/pytrip/vdx.py
+++ b/pytrip/vdx.py
@@ -1244,7 +1244,11 @@ class Contour:
 
         :returns: a str holding the contour points needed for a Voxelplan formatted file.
         """
-        _zoffset = self.cube.slice_pos[0]
+        if self.cube is None:
+            _zoffset = 0.0
+        else:
+            _zoffset = self.cube.slice_pos[0]
+
         out = ""
         for i, cnt in enumerate(self.contour):
             out += " %.3f %.3f %.3f %.3f %.3f %.3f\n" % (cnt[0], cnt[1], _zoffset + cnt[2], 0, 0, 0)


### PR DESCRIPTION
This PR does not resolve the original issue presented in https://github.com/pytrip/pytripgui/issues/58

It should resolve #250 however, since several slices were not mapped to the right z-values.

This PR may require an update of pytripgui.