### PR TITLE
Suggestion to expose general cube class for all non-TRiP data objects…

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -80,7 +80,7 @@ install:
   - conda create -q --name python%PYTHON_VERSION% python=%PYTHON_VERSION%
   - activate python%PYTHON_VERSION%
 # as scipy doesn't yet have wheels for windows, install it using conda
-  - conda install -q --name python%PYTHON_VERSION% scipy
+  - conda install -q --name python%PYTHON_VERSION% scipy<0.19
 # install usual requirements
   - pip install --upgrade -r tests/requirements-test.txt
   - pip install --upgrade -r requirements.txt

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -80,7 +80,7 @@ install:
   - conda create -q --name python%PYTHON_VERSION% python=%PYTHON_VERSION%
   - activate python%PYTHON_VERSION%
 # as scipy doesn't yet have wheels for windows, install it using conda
-  - conda install -q --name python%PYTHON_VERSION% scipy<0.19
+  - conda install -q --name python%PYTHON_VERSION% "scipy<0.19"
 # install usual requirements
   - pip install --upgrade -r tests/requirements-test.txt
   - pip install --upgrade -r requirements.txt

--- a/pytrip/__init__.py
+++ b/pytrip/__init__.py
@@ -33,7 +33,6 @@ from pytrip.raster import Rst
 from pytrip.let import LETCube
 from pytrip.ctimage import CTImages
 from pytrip.dicomhelper import read_dicom_folder
-from pytrip.util import load
 
 # from https://docs.python.org/3/tutorial/modules.html
 # if a package's __init__.py code defines a list named __all__,

--- a/pytrip/__init__.py
+++ b/pytrip/__init__.py
@@ -24,6 +24,7 @@ TODO: documentation here.
 # flake8: noqa
 
 import logging
+from pytrip.cube import Cube
 from pytrip.ctx import CtxCube
 from pytrip.dos import DosCube
 from pytrip.vdx import VdxCube, Voi
@@ -43,3 +44,7 @@ __all__ = ['CtxCube', 'VdxCube', 'Voi', 'DosCube', 'DensityCube', 'LETCube', 'di
 # to prevent it, we add null logging handler, as suggested by Python documentation:
 # as described here: https://docs.python.org/3/howto/logging.html#library-config
 logging.getLogger(__name__).addHandler(logging.NullHandler())
+
+from ._version import get_versions
+__version__ = get_versions()['version']
+del get_versions

--- a/pytrip/__init__.py
+++ b/pytrip/__init__.py
@@ -33,6 +33,7 @@ from pytrip.raster import Rst
 from pytrip.let import LETCube
 from pytrip.ctimage import CTImages
 from pytrip.dicomhelper import read_dicom_folder
+from pytrip.util import load
 
 # from https://docs.python.org/3/tutorial/modules.html
 # if a package's __init__.py code defines a list named __all__,
@@ -44,7 +45,3 @@ __all__ = ['CtxCube', 'VdxCube', 'Voi', 'DosCube', 'DensityCube', 'LETCube', 'di
 # to prevent it, we add null logging handler, as suggested by Python documentation:
 # as described here: https://docs.python.org/3/howto/logging.html#library-config
 logging.getLogger(__name__).addHandler(logging.NullHandler())
-
-from ._version import get_versions
-__version__ = get_versions()['version']
-del get_versions

--- a/pytrip/cube.py
+++ b/pytrip/cube.py
@@ -42,8 +42,8 @@ logger = logging.getLogger(__name__)
 
 class Cube(object):
     """ Top level class for 3-dimensional data cubes used by e.g. DosCube, CtxCube and LETCube.
-    Otherwise, this cube class may be used for storing different kinds of data, such as number of cells,
-    oxygenation level, surviving fraction, etc.
+    The user should not use this class directly, but is instead referred to DosCube, CtxCube, LETCube classes
+    and similar, as these inherits the Cube class and expose all attributes and methods from Cube.
     """
     def __init__(self, cube=None):
         if cube is not None:
@@ -918,3 +918,13 @@ class Cube(object):
             cube = cube.byteswap()
         cube.tofile(path)
         return
+
+    @classmethod
+    def save(cls, path):
+        """ Saves the object as a pickle object.
+        :params: path where file is stored.
+        """
+
+        import pickle
+        with open(path, 'wb') as f:
+            pickle.dump(cls, f, pickle.HIGHEST_PROTOCOL)

--- a/pytrip/cube.py
+++ b/pytrip/cube.py
@@ -918,13 +918,3 @@ class Cube(object):
             cube = cube.byteswap()
         cube.tofile(path)
         return
-
-    @classmethod
-    def save(cls, path):
-        """ Saves the object as a pickle object.
-        :params: path where file is stored.
-        """
-
-        import pickle
-        with open(path, 'wb') as f:
-            pickle.dump(cls, f, pickle.HIGHEST_PROTOCOL)

--- a/pytrip/cube.py
+++ b/pytrip/cube.py
@@ -42,8 +42,8 @@ logger = logging.getLogger(__name__)
 
 class Cube(object):
     """ Top level class for 3-dimensional data cubes used by e.g. DosCube, CtxCube and LETCube.
-    The user should not use this class directly, but is instead referred to DosCube, CtxCube, LETCube classes
-    and similar, as these inherits the Cube class and expose all attributes and methods from Cube.
+    Otherwise, this cube class may be used for storing different kinds of data, such as number of cells,
+    oxygenation level, surviving fraction, etc.
     """
     def __init__(self, cube=None):
         if cube is not None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,6 @@ numpy ; python_version < '3.0' or python_version >= '3.4' # newest numpy for py 
 # matplotlib starting from 2.0, doesn't work well, see issue #226 and others
 matplotlib<=1.5.3 
 pydicom
-scipy<0.16.1 ; python_version >= '3.2' and python_version < '3.4' # newer versions of scipy doesn't have manylinux1 package for python 3.3
-scipy ; python_version < '3.2' or python_version >= '3.4' # newest numpy for py 2.7, 3.4 and higher
+scipy<0.16.1 ; (python_version >= '3.2' and python_version < '3.4') and (os_name != 'nt') # newer versions of scipy doesn't have manylinux1 package for python 3.3
+scipy<0.19 ; os_name == 'nt'
+scipy ; (python_version < '3.2' or python_version >= '3.4') and (os_name != 'nt') # newest numpy for py 2.7, 3.4 and higher


### PR DESCRIPTION
Closes #310, #309, #308, #307

Requires: all data are always stored as float32, see this comment: https://github.com/pytrip/pytrip/issues/303#issuecomment-285979280