### PR TITLE
add extensible .exec parser with minimal features

### DIFF
--- a/pytrip/tripexecuter/__init__.py
+++ b/pytrip/tripexecuter/__init__.py
@@ -23,8 +23,9 @@ The tripexecuter module provides functions for executing TRiP98 locally or remot
 from pytrip.tripexecuter.field import Field
 from pytrip.tripexecuter.execute import Execute
 from pytrip.tripexecuter.plan import Plan
+from pytrip.tripexecuter.execparser import ExecParser
 
 # from https://docs.python.org/3/tutorial/modules.html
 # if a package's __init__.py code defines a list named __all__,
 # it is taken to be the list of module names that should be imported when from package import * is encountered.
-__all__ = ['Field', 'Execute', 'Plan']
+__all__ = ['Field', 'Execute', 'Plan', 'ExecParser']

--- a/pytrip/tripexecuter/execparser.py
+++ b/pytrip/tripexecuter/execparser.py
@@ -42,7 +42,7 @@ class ExecParser(object):
                       "optimize": "_parse_opt",
                       "scancap": "_parse_scancap"}
 
-    # scancap arguments. {<trip_parameter> : <pte.plan.attribute>}
+    # scancap arguments. {<trip_parameter> : (<handler_method>, <format_specifier>)}
     _scancap_args = {"offh2o": ("_update_obj", "f"),
                      "bolus": ("_na", "s"),
                      "focus2stepsizefactor": ("_na", "s"),
@@ -52,7 +52,7 @@ class ExecParser(object):
                      "couchangle": ("_na", "s"),
                      "gantryangle": ("_na", "s")}
 
-    # generic plan arguments. {<trip_parameter> : <pte.plan.attribute>}
+    # generic plan arguments. {<trip_parameter> : (<handler_method>, <format_specifier>)}
     _plan_args = {"dose": ("_na", "s"),
                   "targettissue": ("_na", "s"),
                   "residualtissue": ("_na", "s"),
@@ -61,7 +61,7 @@ class ExecParser(object):
                   "outcube": ("_na", "s"),
                   "debug": ("_na", "s")}
 
-    # generic plan arguments. {<trip_parameter> : <pte.plan.attribute>}
+    # optimization arguments. {<trip_parameter> : (<handler_method>, <format_specifier>)}
     _opt_args = {"iter": ("_na", "s"),
                  "graceiter": ("_na", "s"),
                  "bio": ("_na", "s"),
@@ -81,6 +81,7 @@ class ExecParser(object):
                  "field": ("_na", "s"),
                  "debug": ("_na", "s")}
 
+    # field specific arguments. {<trip_parameter> : (<handler_method>, <format_specifier>)}
     _field_args = {"file": ("_na", "s"),
                    "import": ("_na", "s"),
                    "export": ("_na", "s"),

--- a/pytrip/tripexecuter/execparser.py
+++ b/pytrip/tripexecuter/execparser.py
@@ -1,0 +1,243 @@
+#
+#    Copyright (C) 2010-2017 PyTRiP98 Developers.
+#
+#    This file is part of PyTRiP98.
+#
+#    PyTRiP98 is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    PyTRiP98 is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with PyTRiP98.  If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+Parser for TRiP files.
+"""
+
+import os
+# import uuid
+import logging
+
+from pytrip.tripexecuter import Field
+
+
+logger = logging.getLogger(__name__)
+
+
+class ExecParser(object):
+    """
+    """
+
+    # map trip commands onto method names
+    _trip_commands = {"ct": "_parse_ct",
+                      "field": "_parse_field",
+                      "plan": "_parse_plan",
+                      "opt": "_parse_opt",
+                      "optimize": "_parse_opt",
+                      "scancap": "_parse_scancap"}
+
+    # scancap arguments. {<trip_parameter> : <pte.plan.attribute>}
+    _scancap_args = {"offh2o": ("_update_obj", "f"),
+                     "bolus": ("_na", "s"),
+                     "focus2stepsizefactor": ("_na", "s"),
+                     "calbibration": ("_na", "s"),
+                     "path": ("_na", "s"),
+                     "rifi": ("_na", "s"),
+                     "couchangle": ("_na", "s"),
+                     "gantryangle": ("_na", "s")}
+
+    # generic plan arguments. {<trip_parameter> : <pte.plan.attribute>}
+    _plan_args = {"dose": ("_na", "s"),
+                  "targettissue": ("_na", "s"),
+                  "residualtissue": ("_na", "s"),
+                  "partialbiodose": ("_na", "s"),
+                  "incube": ("_na", "s"),
+                  "outcube": ("_na", "s"),
+                  "debug": ("_na", "s")}
+
+    # generic plan arguments. {<trip_parameter> : <pte.plan.attribute>}
+    _opt_args = {"iter": ("_na", "s"),
+                 "graceiter": ("_na", "s"),
+                 "bio": ("_na", "s"),
+                 "phys": ("_na", "s"),
+                 "H2Obased": ("_na", "s"),
+                 "CTbased": ("_na", "s"),
+                 "singly": ("_na", "s"),
+                 "matchonly": ("_na", "s"),
+                 "dosealgorithm": ("_na", "s"),
+                 "bioalgorithm": ("_na", "s"),
+                 "optalgorithm": ("_na", "s"),
+                 "events": ("_na", "s"),
+                 "eps": ("_na", "s"),
+                 "geps": ("_na", "s"),
+                 "myfac": ("_na", "s"),
+                 "doseweightfactor": ("_na", "s"),
+                 "field": ("_na", "s"),
+                 "debug": ("_na", "s")}
+
+    _field_args = {"file": ("_na", "s"),
+                   "import": ("_na", "s"),
+                   "export": ("_na", "s"),
+                   "read": ("_na", "s"),
+                   "write": ("_na", "s"),
+                   "list": ("_na", "s"),
+                   "delete": ("_na", "s"),
+                   "display": ("_na", "s"),
+                   "inspect": ("_na", "s"),
+                   "reset": ("_na", "s"),
+                   "new": ("_na", "s"),
+                   "reverseorder": ("_na", "s"),
+                   "target": ("_na", "s"),
+                   "gantry": ("_na", "s"),
+                   "couch": ("_na", "s"),
+                   "chair": ("_na", "s"),
+                   "stereotacticcoordinates": ("_na", "s"),
+                   "fwhm": ("_na", "s"),
+                   "rastersteps": ("_na", "s"),
+                   "raster": ("_na", "s"),  # abbreviated of the above # TODO: can we implement some pointer/alias?
+                   "zsteps": ("_na", "s"),
+                   "beam": ("_na", "s"),
+                   "weight": ("_na", "s"),
+                   "contourextension": ("_na", "s"),
+                   "contourext": ("_na", "s"),  # abbreviated of the above
+                   "doseextension": ("_na", "s"),
+                   "doseext": ("_na", "s"),  # abbreviated of the above
+                   "projectile": ("_na", "s"),
+                   "proj": ("_na", "s"),  # abbreviated of the above
+                   "bev": ("_na", "s"),
+                   "nolateral": ("_na", "s"),
+                   "raw": ("_na", "s"),
+                   "dosemeanlet": ("_na", "s"),
+                   "algorithm": ("_na", "s"),
+                   "bioalgorithm": ("_na", "s"),
+                   "debug": ("_na", "s")}
+
+    def __init__(self, plan):
+        self.plan = plan
+
+    def _parse_exec(self, path):
+        """ Parse an .exec file and store it into self.plan
+
+        :params str path: path to .exec file including file extension
+        """
+        self.folder = os.path.dirname(path)
+        with open(path, "r") as fp:
+            data = fp.read()
+
+        data = data.split("\n")
+
+        for line in data:
+            _key = line.split(" ")[0]  # get first word of line
+            if _key in self._trip_commands:
+                # lookup and call corresponding method
+                logger.debug("Calling self {:s}".format(self._trip_commands[_key]))
+                getattr(self, self._trip_commands[_key])(line)
+
+    @staticmethod
+    def _unpack_arg(_arg):
+        """ Returns the interior of the paranthesis of an argument.
+        Any quotes will be stripped from the subarg.
+        Any whitespaces will be stripped from the subarg or arg.
+
+        example:
+        _arg = "bolus(2.00)"
+
+        will return
+
+        "bolus", "2.00"
+
+        """
+        _subarg = _arg[_arg.find("(")+1:_arg.find(")")].strip("\"").strip("\'").strip()
+        _arg = _arg[0:_arg.find("(")].strip()
+        return _arg, _subarg
+
+    def _parse_extra_args(self, _line, _dict, _obj):
+        """
+        Parse all args following the "/" in a given line and a given parsing dictionary.
+        The parsing dictionary maps the TRiP parameter ( == argument) with a proper method.
+
+        :params _obj: may either be self.plan or self.plan.fields[i]
+
+        """
+        items = _line.split("/")
+        if len(items) > 1:
+            _args = items[1].split()
+            for _arg in _args:
+                _par, _val = self._unpack_arg(_arg)  # returns always string
+                # _par holds the argument/parameter name
+                # _val holds the value for the argument/parameter
+
+                # now lookup a proper method from the dict
+                if _par in _dict:
+                    _method = _dict[_par][0]
+                    _format = _dict[_par][1]
+                    # _method is the name of the method to be called (key in the dicts above)
+                    # _obj is the target object (the base plan or a given field)
+                    # _format is the format specifier how the _val should be stored in _par for the _obj class
+                    getattr(self, _method)(_obj, _par, _val, _format)
+
+    def _parse_ct(self, line):
+        """ Parses the 'ct' command arguments
+        """
+        items = line.split("/")
+        if len(items) > 1:
+            path = items[0].split()[1]
+            args = items[1].split()
+            if "read" in args:
+                self.plan.basename = path
+
+    def _parse_plan(self, line):
+        """
+        Method for parsing plan data
+        """
+        self._parse_extra_args(line, self._plan_args, self.plan)
+
+    def _parse_field(self, line):
+        """
+        Method for parsing field data
+        """
+        if "new" in line:
+            field = Field()
+            self.plan.fields.append(field)
+            self._parse_extra_args(line, self._field_args, self.plan.fields[-1])
+
+    def _parse_scancap(self, line):
+        """
+        Generic parser
+        """
+        self._parse_extra_args(line, self._scancap_args, self.plan)
+
+    def _parse_opt(self, line):
+        """
+        Not implemented.
+        """
+        pass
+
+    @staticmethod
+    def _update_obj(_obj, _par, _val, _format):
+        """
+        :params _obj: object whose paramters will be updated
+        :params _par: attribute to be set in obj
+        :params _val: variable which this attribute will be set to
+        """
+        # Add all needed type conversions here:
+        if _format == 'f':
+            value = float(_val)
+        elif _format == 'i':
+            value = int(_val)
+        else:
+            value = _val
+        setattr(_obj, _par, value)
+
+    @staticmethod
+    def _na(_obj, _arg1, _arg2, _format):
+        """ None Applicable.
+        This method simply prints a N/A warning and exits.
+        """
+        logger.warning("Not implmented: '{:s}={:s} format={:s}'".format(_arg1, _arg2, _format))

--- a/pytrip/tripexecuter/execparser.py
+++ b/pytrip/tripexecuter/execparser.py
@@ -155,17 +155,17 @@ class ExecParser(object):
     def _unpack_arg(_arg):
         """ Returns the interior of the paranthesis of an argument.
 
-        'arg(subarg)'     -> 'arg', 'subarg'
-        'arg("subarg")'   -> 'arg', 'subarg'
-        'arg('subarg')'   -> 'arg', 'subarg'
-        'arg'             -> 'arg', ''
-        '"arg"'           -> 'arg', ''
-        ''arg''           -> 'arg', ''
+        'arg(value)'     -> 'arg', 'value'
+        'arg("value")'   -> 'arg', 'value'
+        'arg('value')'   -> 'arg', 'value'
+        'arg'            -> 'arg', ''
+        '"arg"'          -> 'arg', ''
+        ''arg''          -> 'arg', ''
 
-        Any quotes will be stripped from the subarg.
-        Any whitespaces will be stripped from the subarg or arg.
+        Any quotes will be stripped from the value.
+        Any whitespaces will be stripped from the value or arg.
 
-        If there is no subargument given, simply the _arg is returned and an empty string for the subarg.
+        If there is no value given, simply the _arg is returned and an empty string for the value.
 
         example:
         >>> _unpack_arg("bolus(2.00)")
@@ -173,12 +173,12 @@ class ExecParser(object):
 
         """
         if "(" in _arg:
-            _subarg = _arg[_arg.find("(")+1:_arg.find(")")].strip("\"").strip("\'").strip()
+            _val = _arg[_arg.find("(")+1:_arg.find(")")].strip("\"").strip("\'").strip()
             _arg = _arg[0:_arg.find("(")].strip()
         else:
+            _val = ""
             _arg = _arg.strip("\"").strip("\'").strip()
-            _subarg = ""
-        return _arg, _subarg
+        return _arg, _val
 
     def _parse_extra_args(self, _line, _dict, _obj):
         """

--- a/pytrip/tripexecuter/field.py
+++ b/pytrip/tripexecuter/field.py
@@ -52,8 +52,8 @@ class Field(object):
         self.number = 1  # Field number. First field must be 1
         self.gantry = 0.0  # TRiP98 angles assumed here.
         self.couch = 0.0  # TRiP98 angles assumed here.
-        self.fwhm = 4.0  # in [mm]
-        self.raster_step = [2, 2]  # spot width in [mm]
+        self.fwhm = 4.0  # spot width in [mm]
+        self.raster_step = [2, 2]  # spot distance in [mm]
         self.dose_extension = 1.2  # see TRiP98 field / doseext() documentation
         self.contour_extension = 0.6  # see TRiP98 field / contourext() documentation
 
@@ -91,7 +91,7 @@ class Field(object):
         out += "|  Couch angle                  : {:.2f} deg\n".format(self.couch)
         out += "|  Gantry angle                 : {:.2f} deg\n".format(self.gantry)
         out += "|\n"
-        out += "|  Spot size (FWHM              : {:.2f} mm\n".format(self.fwhm)
+        out += "|  Spot size (FWHM)             : {:.2f} mm\n".format(self.fwhm)
         out += "|  Raster step size (x,y)       : {:.2f}, {:.2f} mm\n".format(self.raster_step[0],
                                                                               self.raster_step[1])
         out += "|  Z-steps                      : {:.2f} mm\n".format(self.zsteps)

--- a/pytrip/tripexecuter/plan.py
+++ b/pytrip/tripexecuter/plan.py
@@ -280,11 +280,10 @@ class Plan(object):
             f.write(self._trip_exec)
 
     def read_exec(self, exec_path):
-        """ Reads an .exec file onto self.        
+        """ Reads an .exec file onto self.
         """
         exec = ExecParser(self)
         exec._parse_exec(exec_path)
-                               
 
     def save_data(self, images, path):
         """ Save this plan, including associated data.
@@ -379,7 +378,7 @@ class Plan(object):
 
         output = []
         output.append("* {:s} created by PyTRiP98 on the {:s}".format(self.basename + ".exec",
-                                                                      str(datetime.datetime.now())))        
+                                                                      str(datetime.datetime.now())))
         # TODO: add user and host
         # We can only check if dir exists, if this is supposed to run locally.
 

--- a/pytrip/tripexecuter/plan.py
+++ b/pytrip/tripexecuter/plan.py
@@ -30,6 +30,7 @@ import logging
 from pytrip.dos import DosCube
 from pytrip.let import LETCube
 from pytrip.tripexecuter.execute import Execute
+from pytrip.tripexecuter.execparser import ExecParser
 
 logger = logging.getLogger(__name__)
 
@@ -156,7 +157,10 @@ class Plan(object):
         out += "   Plan '{:s}'\n".format(self.basename)
         out += "----------------------------------------------------------------------------\n"
         out += "|  UUID                         : {:s}\n".format(str(self.__uuid__))
-        out += "|  Target VOI                   : {:s}\n".format(self.voi_target.name)
+        if self.voi_target:
+            out += "|  Target VOI                   : {:s}\n".format(self.voi_target.name)
+        else:
+            out += "|  Target VOI                   : (none set)\n"
         if self.vois_oar:
             for _oar in self.vois_oar:
                 out += "|  Organs at Risk VOIs          : {:s}\n".format(_oar.name)
@@ -166,9 +170,9 @@ class Plan(object):
         if self.fields:
             out += "+---Fields\n"
             for _field in self.fields:
-                out += "|   |           #{:d}              : {:s}\n".format(_field.number, _field.basename)
+                out += "|   |           #{:d}              : '{:s}'\n".format(_field.number, _field.basename)
         else:
-            out += "|  Fields                       : (none set)\n"
+            out += "|   Fields                      : (none set)\n"
 
         if self.dosecubes:
             out += "+---Dose cubes:\n"
@@ -275,6 +279,13 @@ class Plan(object):
         with open(exec_path, "w") as f:
             f.write(self._trip_exec)
 
+    def read_exec(self, exec_path):
+        """ Reads an .exec file onto self.        
+        """
+        exec = ExecParser(self)
+        exec._parse_exec(exec_path)
+                               
+
     def save_data(self, images, path):
         """ Save this plan, including associated data.
         TODO: may have to be implemented in a better way.
@@ -368,10 +379,12 @@ class Plan(object):
 
         output = []
         output.append("* {:s} created by PyTRiP98 on the {:s}".format(self.basename + ".exec",
-                                                                      str(datetime.datetime.now())))
+                                                                      str(datetime.datetime.now())))        
         # TODO: add user and host
         # We can only check if dir exists, if this is supposed to run locally.
-        # TODO: add UUID of plan inro header?
+
+        output.append("*$$$ Plan UUID {:s}".format(self.UUID))
+        output.append("*")
         output.append("time / on")
         output.append("sis  * /delete")
         output.append("hlut * /delete")

--- a/pytrip/tripexecuter/plan.py
+++ b/pytrip/tripexecuter/plan.py
@@ -382,7 +382,8 @@ class Plan(object):
         # TODO: add user and host
         # We can only check if dir exists, if this is supposed to run locally.
 
-        output.append("*$$$ Plan UUID {:s}".format(self.UUID))
+        if hasattr(self, "UUID"):
+            output.append("*$$$ Plan UUID {:s}".format(self.UUID))
         output.append("*")
         output.append("time / on")
         output.append("sis  * /delete")

--- a/pytrip/tripexecuter/plan.py
+++ b/pytrip/tripexecuter/plan.py
@@ -282,8 +282,8 @@ class Plan(object):
     def read_exec(self, exec_path):
         """ Reads an .exec file onto self.
         """
-        exec = ExecParser(self)
-        exec._parse_exec(exec_path)
+        _exec = ExecParser(self)
+        _exec._parse_exec(exec_path)
 
     def save_data(self, images, path):
         """ Save this plan, including associated data.

--- a/tests/res/TST003/EXEC/TST003101.exec
+++ b/tests/res/TST003/EXEC/TST003101.exec
@@ -1,0 +1,43 @@
+* 1H plan on a 5 cm diameter sphere in a 256x256 x300 mm water phantom.
+* In this case there are 100 slices of 3 mm thickness. 
+* X and Y are 256 x 256, each pixel is 1 x1 mm.
+*
+* /Niels Bassler <bassler@phys.au.dk> 22nd July 2013
+*
+*makegeometry ifjcell /  ctdim(256,256,300) ctsteps(1,1,3) ctnum(0) centre(128,128,150) shape(box(20,20,20))
+
+
+scancap / bolus(5.6) offh2o(1.234) minparticles(5678) path(uw2) rifi(3.333)
+
+sis  * /delete
+hlut * /delete
+ddd  * /delete
+dedx * /delete
+
+* 1H
+sis "$TRIP98/DATA/SIS/1H.sis" / read
+ddd "$TRIP98/DATA/DDD/1H/RF0MM/1H*" / read
+spc "$TRIP98/DATA/SPC/1H/RF0MM/1H*" / read
+dedx "$TRIP98/DATA/DEDX/20040607.dedx" /read
+hlut "$TRIP98/DATA/HLUT/19990218.hlut" /read
+
+ct "tst003000" / read
+voi "tst003000" / read select(target)
+voi target / maxdosefraction(0.9)
+
+random 100
+field 1 / new fwhm(4.1) raster(2,3) couch(-45.6) gantry(12.3) zstep(3.1) proj(1H)
+
+plan / dose(2.34)
+opt / field(*) phys CTbased dosealg(ms) optalg(bf) geps(1e-4) eps(1e-3) iter(500)
+
+field 1 / file(tst003001.bev.gd) bev(*) nolateral 
+field 1 / file(tst003001.bevlet.gd) bev(*) dosemeanlet
+field 1 / file(tst003001.rst) reverseorder write
+
+dose "tst003001.dos" / calculate field(*) write
+dose "tst003001.dos" / calculate field(*) dosemeanlet write
+
+quit
+
+

--- a/tests/res/TST003/EXEC/TST003101.exec
+++ b/tests/res/TST003/EXEC/TST003101.exec
@@ -5,7 +5,9 @@
 * /Niels Bassler <bassler@phys.au.dk> 22nd July 2013
 *
 *makegeometry ifjcell /  ctdim(256,256,300) ctsteps(1,1,3) ctnum(0) centre(128,128,150) shape(box(20,20,20))
-
+*
+* This file is ONLY for checking the PyTRiP parser
+* and not supposed to be any reasonable plan for TRiP calculations
 
 scancap / bolus(5.6) offh2o(1.234) minparticles(5678) path(uw2) rifi(3.333)
 
@@ -26,7 +28,9 @@ voi "tst003000" / read select(target)
 voi target / maxdosefraction(0.9)
 
 random 100
-field 1 / new fwhm(4.1) raster(2,3) couch(-45.6) gantry(12.3) zstep(3.1) proj(1H)
+field 1 / new fwhm(4.1) raster(2,3) couch(-13.9) gantry(46.7) zstep(3.4) proj(1H) contourext(0.12) doseext(0.21)
+field 2 / new fwhm(4.2) raster(3,2) couch(-22.8) gantry(55.6) zstep(3.5) proj(1H) contourext(0.67) doseext(0.76)
+field 3 / new fwhm(4.3) raster(2,2) couch(-31.7) gantry(64.5) zstep(3.6) proj(1H) contourext(0.23) doseext(0.32)
 
 plan / dose(2.34)
 opt / field(*) phys CTbased dosealg(ms) optalg(bf) geps(1e-4) eps(1e-3) iter(500)

--- a/tests/test_exec_read.py
+++ b/tests/test_exec_read.py
@@ -22,13 +22,13 @@ import os
 import unittest
 import logging
 
-import pytrip as pt
 import pytrip.tripexecuter as pte
 
 import tests.base
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.INFO)
+# logging.basicConfig(level=logging.INFO)
+
 
 class TestParseExec(unittest.TestCase):
     """ Tests for pytrip.tripexecuter.execparser
@@ -37,7 +37,7 @@ class TestParseExec(unittest.TestCase):
         """ Prepare test environment.
         """
         self.exec_name = "TST003001.exec"
-        
+
         testdir = tests.base.get_files()
         _exec_dir = os.path.join(testdir, "EXEC")
         self.exec_path = os.path.join(_exec_dir, self.exec_name)
@@ -51,6 +51,6 @@ class TestParseExec(unittest.TestCase):
         plan.read_exec(self.exec_path)
         print(plan)
 
+
 if __name__ == '__main__':
     unittest.main()
-

--- a/tests/test_exec_read.py
+++ b/tests/test_exec_read.py
@@ -1,0 +1,56 @@
+#
+#    Copyright (C) 2010-2017 PyTRiP98 Developers.
+#
+#    This file is part of PyTRiP98.
+#
+#    PyTRiP98 is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    PyTRiP98 is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with PyTRiP98.  If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+"""
+import os
+import unittest
+import logging
+
+import pytrip as pt
+import pytrip.tripexecuter as pte
+
+import tests.base
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+class TestParseExec(unittest.TestCase):
+    """ Tests for pytrip.tripexecuter.execparser
+    """
+    def setUp(self):
+        """ Prepare test environment.
+        """
+        self.exec_name = "TST003001.exec"
+        
+        testdir = tests.base.get_files()
+        _exec_dir = os.path.join(testdir, "EXEC")
+        self.exec_path = os.path.join(_exec_dir, self.exec_name)
+
+    def test_exec_parse(self):
+        """
+        """
+        logger.info("Test parsing '{:s}'".format(self.exec_path))
+
+        plan = pte.Plan()
+        plan.read_exec(self.exec_path)
+        print(plan)
+
+if __name__ == '__main__':
+    unittest.main()
+

--- a/tests/test_exec_read.py
+++ b/tests/test_exec_read.py
@@ -36,7 +36,7 @@ class TestParseExec(unittest.TestCase):
     def setUp(self):
         """ Prepare test environment.
         """
-        self.exec_name = "TST003001.exec"
+        self.exec_name = "TST003101.exec"
 
         testdir = tests.base.get_files()
         _exec_dir = os.path.join(testdir, "EXEC")

--- a/tests/test_exec_read.py
+++ b/tests/test_exec_read.py
@@ -50,6 +50,8 @@ class TestParseExec(unittest.TestCase):
         plan = pte.Plan()
         plan.read_exec(self.exec_path)
         print(plan)
+        for field in plan.fields:
+            print(field)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
A possible .exec parser.
So far only "offh2o" from `scancap` is activated.

If this is acceptable, then the goal for this merge would be to have something minimal which at least can load the fields (couch/gantry angle).

Closes #376 
Related: https://github.com/pytrip/pytripgui/issues/127