### PR TITLE
pytest-xdist version limited on python 3.2 and Windows

### DIFF
--- a/tests/requirements-test.txt
+++ b/tests/requirements-test.txt
@@ -4,8 +4,8 @@ pytest<3.0 ; python_version >= '3.2' and python_version < '3.3' or os_name == 'n
 pytest ; python_version < '3.0' and python_version >= '3.3' and os_name != 'nt' # py different than 3.2
 pytest-capturelog
 pytest-timeout
-pytest-xdist
-pytest-cov ; python_version != '3.2'
+pytest-xdist ; (python_version < '3.0' or python_version >= '3.3') and os_name != 'nt' # py different than 3.2
+pytest-xdist<1.18.0  ; python_version >= '3.2' and python_version < '3.3' or os_name == 'nt' # py 3.2 or Windpytest-cov ; python_version != '3.2'
 tox
 scipy<0.16.1 ; (python_version >= '3.2' and python_version < '3.4') and (os_name != 'nt') # newer versions of scipy doesn't have manylinux1 package for python 3.3
 scipy<0.20 ; os_name == 'nt' # all Windows versions

--- a/tests/requirements-test.txt
+++ b/tests/requirements-test.txt
@@ -6,6 +6,7 @@ pytest-capturelog
 pytest-timeout
 pytest-xdist ; (python_version < '3.0' or python_version >= '3.3') and os_name != 'nt' # py different than 3.2
 pytest-xdist<1.18.0  ; python_version >= '3.2' and python_version < '3.3' or os_name == 'nt' # py 3.2 or Windpytest-cov ; python_version != '3.2'
+pytest-cov ; python_version != '3.2'
 tox
 scipy<0.16.1 ; (python_version >= '3.2' and python_version < '3.4') and (os_name != 'nt') # newer versions of scipy doesn't have manylinux1 package for python 3.3
 scipy<0.20 ; os_name == 'nt' # all Windows versions


### PR DESCRIPTION
Fixes #378 