### PR TITLE
fix load dicom bug in new API

### DIFF
--- a/pytrip/cube.py
+++ b/pytrip/cube.py
@@ -924,7 +924,9 @@ class Cube(object):
             logger.warning("Overlapping slices found: slice thickness is larger than the slice distance.")
 
         self.set_byteorder()
-        self._set_format_str_from_dicom()
+        self.data_type = "integer"
+        self.num_bytes = 2
+        self._set_format_str()
         self.header_set = True
 
         # unique for whole structure set


### PR DESCRIPTION
This is only used for writing the .ctx cube, so I choose the standard format here.
Fixes #380 

Related to #22 would be nice, then we can add some DICOM tests, preventing cases like this.

