### PR TITLE
Bug fixes in tripexecuter. .vdx path is retained in VDX object.

### DIFF
--- a/pytrip/dos.py
+++ b/pytrip/dos.py
@@ -54,7 +54,7 @@ class DosCube(Cube):
         """
         super(DosCube, self).__init__(cube)
         self.type = "DOS"
-        self.target_dose = 0.0
+        self.target_dose = 0.0  # Target dose in Gy or Gy(RBE)
 
         # UIDs unique for whole structure set
         # generation of UID is done here in init, the reason why we are not generating them in create_dicom

--- a/pytrip/tripexecuter/execute.py
+++ b/pytrip/tripexecuter/execute.py
@@ -99,10 +99,8 @@ class Execute(object):
     def _print(self):
         """ Pretty print current attributes.
         """
-        out = ""
-
-        out += "|\n"
-        out += "   Executer"
+        out = "\n"
+        out += "   Executer\n"
         out += "----------------------------------------------------------------------------\n"
         out += "| General configuration\n"
         out += "|   UUID                        : {:s}\n".format(str(self.__uuid__))
@@ -111,7 +109,6 @@ class Execute(object):
         out += "|   STDOUT prefix               : '{:s}'\n".format(self.logfile_prefix_stdout)
         out += "|   STDERR prefix               : '{:s}'\n".format(self.logfile_prefix_stderr)
         out += "|   TRiP98 command              : '{:s}'\n".format(self.trip_bin_path)
-        out += "|   Dummy run                   : {:s}\n".format(str(self._norun))
         out += "|   Cleanup                     : {:s}\n".format(str(self._cleanup))
 
         out += "|\n"

--- a/pytrip/tripexecuter/plan.py
+++ b/pytrip/tripexecuter/plan.py
@@ -318,13 +318,13 @@ class Plan(object):
             voi.clean_cache()
 
     def load_dose(self, path, _type, target_dose=0.0):
-        """ Load and append a new DOS cube from path to self.doscubes.
+        """ Load and append a new DosCube from path to self.doscubes.
         """
         dos = DosCube()
         dos.read(os.path.splitext(path)[0] + DosCube.data_file_extension)
         dos._type = _type
-        dos.set_dose(target_dose)
-        self.doscubes.append(dos)
+        dos.target_dose = target_dose
+        self.dosecubes.append(dos)
 
     def destroy(self):
         """ Destructor for Vois and Fields in this class.

--- a/pytrip/vdx.py
+++ b/pytrip/vdx.py
@@ -583,7 +583,7 @@ class Voi:
         out += "----------------------------------------------------------------------------\n"
         out += "|   Name                                : '{:s}'\n".format(self.name)
         out += "|   Is concated                         : {:s}\n".format(str(self.is_concated))
-        out += "|   Type                                : {:d}\n".format(self.type )
+        out += "|   Type                                : {:d}\n".format(self.type)
         out += "|   Number of slices in VOI             : {:d}\n".format(len(self.slices))
         out += "|   Color 0xRGB                         : #{:s}{:s}{:s}\n".format(hex(self.color[0].strip('0x')),
                                                                                   hex(self.color[1].strip('0x')),

--- a/pytrip/vdx.py
+++ b/pytrip/vdx.py
@@ -78,6 +78,7 @@ class VdxCube:
     def __init__(self, cube=None):
         self.vois = []
         self.cube = cube
+        self.path = ""  # full path to .vdx file, set if a regular .vdx file was loaded loaded
 
         # UIDs unique for whole structure set
         # generation of UID is done here in init, the reason why we are not generating them in create_dicom
@@ -96,6 +97,28 @@ class VdxCube:
             import datetime
             self.patient_id = datetime.datetime.today().strftime('%Y%m%d-%H%M%S')
             logger.debug("VDX class creates new patient_id {}".format(self.patient_id))
+
+    def __str__(self):
+        """ str output handler
+        """
+        return self._print()
+
+    def _print(self):
+        """ Pretty print current attributes.
+        """
+        out = "\n"
+        out += "   VdxCube\n"
+        out += "----------------------------------------------------------------------------\n"
+        out += "| UIDs\n"
+        out += "|   dicom_study_instance_uid            : {:s}\n".format(self._dicom_study_instance_uid)
+        out += "|   structs_dicom_series_instance_uid   : '{:s}'\n".format(self._structs_dicom_series_instance_uid)
+        out += "|   structs_sop_instance_uid            : '{:s}'\n".format(self._structs_sop_instance_uid)
+        out += "|   structs_rt_series_instance_uid      : '{:s}'\n".format(self._structs_rt_series_instance_uid)
+        if self.vois:
+            out += "+---VOIs\n"
+            for _i, _v in enumerate(vois):
+                out += "|   |           #{:d}              : '{:s}'\n".format(_i, _v.name)
+        return out
 
     def read_dicom(self, data, structure_ids=None):
         """
@@ -153,12 +176,6 @@ class VdxCube:
         names = [voi.name for voi in self.vois]
         return names
 
-    def __str__(self):  # Method for printing
-        """
-        :returns: VOI names separated by '&' sign
-        """
-        return '&'.join(self.get_voi_names())
-
     def add_voi(self, voi):
         """ Appends a new voi to this class.
 
@@ -199,6 +216,7 @@ class VdxCube:
         :param str path: Full path including file extension.
         """
         self.basename = os.path.basename(path).split(".")[0]
+        self.path = path
         fp = open(path, "r")
         content = fp.read().split('\n')
         fp.close()
@@ -551,6 +569,27 @@ class Voi:
         self.slices = []
         self.color = [0, 230, 0]  # default colour
         self.define_colors()
+
+    def __str__(self):
+        """ str output handler
+        """
+        return self._print()
+
+    def _print(self):
+        """ Pretty print current attributes.
+        """
+        out = "\n"
+        out += "   Voi\n"
+        out += "----------------------------------------------------------------------------\n"
+        out += "|   Name                                : '{:s}'\n".format(self.name)
+        out += "|   Is concated                         : {:s}\n".format(str(self.is_concated))
+        out += "|   Type                                : {:d}\n".format(self.type )
+        out += "|   Number of slices in VOI             : {:d}\n".format(len(self.slices))
+        out += "|   Color 0xRGB                         : #{:s}{:s}{:s}\n".format(hex(self.color[0].strip('0x')),
+                                                                                  hex(self.color[1].strip('0x')),
+                                                                                  hex(self.color[2].strip('0x')))
+
+        return out
 
     def create_copy(self, margin=0):
         """

--- a/pytrip/vdx.py
+++ b/pytrip/vdx.py
@@ -116,7 +116,7 @@ class VdxCube:
         out += "|   structs_rt_series_instance_uid      : '{:s}'\n".format(self._structs_rt_series_instance_uid)
         if self.vois:
             out += "+---VOIs\n"
-            for _i, _v in enumerate(vois):
+            for _i, _v in enumerate(self.vois):
                 out += "|   |           #{:d}              : '{:s}'\n".format(_i, _v.name)
         return out
 

--- a/tests/test_vdx.py
+++ b/tests/test_vdx.py
@@ -59,7 +59,7 @@ class TestVdx(unittest.TestCase):
         self.assertEqual(v.number_of_vois(), 2)
 
         logger.info("Checking Vdx str method")
-        self.assertEqual(str(v), "target&voi_empty")
+        logger.info(str(v))
 
         logger.info("Checking Vdx write_to_voxel method")
         fd, outfile = tempfile.mkstemp()


### PR DESCRIPTION
Closes #390 and a few additional bugs