### PR TITLE
util.py: basenames returned also for paths

### DIFF
--- a/pytrip/util.py
+++ b/pytrip/util.py
@@ -1,5 +1,5 @@
 #
-#    Copyright (C) 2010-2017 PyTRiP98 Developers.
+#    Copyright (C) 2010-2018 PyTRiP98 Developers.
 #
 #    This file is part of PyTRiP98.
 #
@@ -64,6 +64,7 @@ class TRiP98FilePath(object):
     See http://bio.gsi.de/DOCS/TRiP98/PRO/DOCS/trip98cmddose.html for more details.
 
     """
+
     def __init__(self, name, cube_type):
         """
         Creates a helper class to deal with TRiP98 filenames.
@@ -369,7 +370,7 @@ class TRiP98FilePath(object):
 
         :return:  path to the (unzipped) data file.
         """
-        return self._filename_without_extension
+        return os.path.basename(self._filename_without_extension)
 
 
 class TRiP98FileLocator(object):

--- a/pytrip/vdx.py
+++ b/pytrip/vdx.py
@@ -1,5 +1,5 @@
 #
-#    Copyright (C) 2010-2017 PyTRiP98 Developers.
+#    Copyright (C) 2010-2018 PyTRiP98 Developers.
 #
 #    This file is part of PyTRiP98.
 #
@@ -83,6 +83,14 @@ class VdxCube:
     >>> v = pt.VdxCube(c)
     >>> v.read("tests/res/TST003/tst003000.vdx")
     """
+
+    # stictly, VDX does not have .hed companion. However, in practice, .vdx files are always
+    # associated with a .hed .ctx cube pair. In order to discover these, the header file
+    # extentions may be associated to this as a .vdx data file.
+
+    header_file_extension = '.hed'
+    data_file_extension = '.vdx'
+    allowed_suffix = tuple()
 
     def __init__(self, cube=None):
         """


### PR DESCRIPTION
Closes #456

```
import pytrip as pt
from pytrip.util import TRiP98FilePath

path = '/home/bassler/Projects/pytripgui/_test/fofofo.hed'
print(TRiP98FilePath(path, pt.CtxCube).basename)
print(TRiP98FilePath(path, pt.VdxCube).basename)
```

output:
```
fofofo
fofofo
```