### PR TITLE
Fix DICOM data element keywords for export

### DIFF
--- a/pytrip/cube.py
+++ b/pytrip/cube.py
@@ -791,6 +791,7 @@ class Cube(object):
         self.primary_view = "transversal"
         self.set_data_type(type(ds.pixel_array[0][0]))
         self.patient_name = ds.PatientName
+        self.patient_id = ds.PatientID
         self.basename = ds.PatientID.replace(" ", "_")
         self.slice_dimension = int(ds.Rows)  # should be changed ?
         self.pixel_size = float(ds.PixelSpacing[0])  # (0028, 0030) Pixel Spacing (DS)
@@ -920,7 +921,7 @@ class Cube(object):
         ds.SeriesInstanceUID = self._ct_dicom_series_instance_uid
 
         # Study Instance UID tag 0x0020,0x000D (type UI - Unique Identifier)
-        ds.FrameofReferenceUID = '1.2.3'  # !!!!!!!!!
+        ds.FrameOfReferenceUID = '1.2.3'  # !!!!!!!!!
         ds.StudyDate = datetime.datetime.today().strftime('%Y%m%d')
         ds.StudyTime = datetime.datetime.today().strftime('%H%M%S')
         ds.PhotometricInterpretation = 'MONOCHROME2'
@@ -933,7 +934,7 @@ class Cube(object):
 
         # Add eclipse friendly IDs
         ds.StudyID = '1'  # Study ID tag 0x0020,0x0010 (type SH - Short String)
-        ds.ReferringPhysiciansName = 'py^trip'  # Referring Physician's Name tag 0x0008,0x0090 (type PN - Person Name)
+        ds.ReferringPhysicianName = 'py^trip'  # Referring Physician's Name tag 0x0008,0x0090 (type PN - Person Name)
         ds.PositionReferenceIndicator = ''  # Position Reference Indicator tag 0x0020,0x1040
         ds.SeriesNumber = '1'  # SeriesNumber tag 0x0020,0x0011 (type IS - Integer String)
 

--- a/pytrip/vdx.py
+++ b/pytrip/vdx.py
@@ -166,7 +166,7 @@ class VdxCube:
             sys.exit()
 
         for i, _roi_contour in enumerate(_contours):
-            if structure_ids is None or _roi_contour.RefdROINumber in structure_ids:
+            if structure_ids is None or _roi_contour.ReferencedROINumber in structure_ids:
                 if hasattr(dcm, "RTROIObservationsSequence"):
                     _roi_observation = dcm.RTROIObservationsSequence[i]
                     # _roi_name = dcm.RTROIObservationsSequence[i].ROIObservationLabel  # OPTIONAL by DICOM
@@ -438,9 +438,9 @@ class VdxCube:
             roi_label = self.vois[i].create_dicom_label()
             roi_label.ObservationNumber = str(i + 1)
             roi_label.ReferencedROINumber = str(i + 1)
-            roi_label.RefdROINumber = str(i + 1)
+            # roi_label.RefdROINumber = str(i + 1)
             roi_contours = self.vois[i].create_dicom_contour_data(i)
-            roi_contours.RefdROINumber = str(i + 1)
+            # roi_contours.RefdROINumber = str(i + 1)
             roi_contours.ReferencedROINumber = str(i + 1)
 
             roi_structure_roi = self.vois[i].create_dicom_structure_roi()
@@ -451,9 +451,9 @@ class VdxCube:
             roi_structure_roi_list.append(roi_structure_roi)
             roi_label_list.append(roi_label)
             roi_data_list.append(roi_contours)
-        ds.RTROIObservations = Sequence(roi_label_list)
-        ds.ROIContours = Sequence(roi_data_list)
-        ds.StructureSetROIs = Sequence(roi_structure_roi_list)
+        ds.RTROIObservationsSequence = Sequence(roi_label_list)
+        ds.ROIContourSequence = Sequence(roi_data_list)
+        ds.StructureSetROISequence = Sequence(roi_structure_roi_list)
         return ds
 
     def write_dicom(self, directory):
@@ -906,7 +906,7 @@ class Voi:
             logger.info("Get contours from slice at {:10.3f} mm".format(_slice.get_position()))
             contours.extend(_slice.create_dicom_contours(dcmcube))
 
-        roi_contours.Contours = Sequence(contours)
+        roi_contours.ContourSequence = Sequence(contours)
         roi_contours.ROIDisplayColor = self.get_color(i)
 
         return roi_contours
@@ -1391,7 +1391,7 @@ class Slice:
                 contour.extend([p[0], p[1], p[2]])
             con.ContourData = contour
             con.ContourGeometricType = 'CLOSED_PLANAR'
-            con.NumberofContourPoints = item.number_of_points()
+            con.NumberOfContourPoints = item.number_of_points()
             cont_image_item = Dataset()
             cont_image_item.ReferencedSOPClassUID = '1.2.840.10008.5.1.4.1.1.2'  # CT Image Storage SOP Class
             cont_image_item.ReferencedSOPInstanceUID = ref_sop_instance_uid  # CT slice Instance UID


### PR DESCRIPTION
Some DICOM data element keywords were incompatible with the current standard and thus not supported by PyDICOM:
http://dicom.nema.org/medical/dicom/current/output/html/part06.html

This caused the following warnings and a corrupted export from PytripGUI:
![image](https://user-images.githubusercontent.com/5843341/129925682-2d7ecbe8-33bc-421a-8784-ecd3e296bf6d.png)