### PR TITLE
add paramiko as extra dep

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -143,7 +143,7 @@ install_requires = [
 
 # oldest NumPy version with support for given python version
 setup_requires = [
-    "numpy==1.21.0 ; python_version >= '3.10'",
+    "numpy==1.21.0 ; python_version == '3.10'",
     "numpy==1.20.0 ; python_version == '3.9'",
     "numpy==1.18.0 ; python_version == '3.8'",
     "numpy==1.15.0 ; python_version == '3.7'",


### PR DESCRIPTION
to install pytrip with paramiko execute
```
python -m pip install pytrip98[remote]
```

you can also install it from local dir
```
python -m pip install --use-feature=in-tree-build /path/to/pytrip[remote]
```

tested on py2.7, py3.5, py3.7, py3.8, py3.9

closes #622 
closes #621 