### PR TITLE
Add __str__ methods for cube types

### DIFF
--- a/pytrip/cube.py
+++ b/pytrip/cube.py
@@ -145,6 +145,9 @@ class Cube(object):
 
             self.z_table = False  # positions are stored in self.slice_pos (list of slice#,pos(mm),thickness(mm),tilt)
 
+    def __str__(self):
+        return "Cube: "+self.basename
+
     def __add__(self, other):
         """ Overload + operator
         """

--- a/pytrip/dos.py
+++ b/pytrip/dos.py
@@ -71,6 +71,11 @@ class DosCube(Cube):
         self._plan_dicom_series_instance_uid = uid.generate_uid(prefix=None)
         self._dose_dicom_series_instance_uid = uid.generate_uid(prefix=None)
 
+    def __str__(self):
+        if self.type == "DOS":
+            return "Dose: " + self.basename
+        return "Dose (type " + self.type + "): " + self.basename
+
     def read_dicom(self, dcm):
         """ Imports the dose distribution from DICOM object.
 

--- a/pytrip/let.py
+++ b/pytrip/let.py
@@ -53,6 +53,11 @@ class LETCube(Cube):
         self.type = "LET"
         self.let_type = None
 
+    def __str__(self):
+        if self.type == "LET":
+            return "LET: " + self.basename
+        return "LET (type " + self.type + "): " + self.basename
+
     def get_max(self):
         """ Returns the largest value in the LETCube.
 


### PR DESCRIPTION
Useful for printing in the GUI's PatientTree.

![image](https://user-images.githubusercontent.com/5843341/138750641-0636e244-f5e8-43af-bc3f-59c6e9e2d4e9.png)
