### PR TITLE
Improve executor messages

### DIFF
--- a/pytrip/tripexecuter/__init__.py
+++ b/pytrip/tripexecuter/__init__.py
@@ -26,8 +26,10 @@ from pytrip.tripexecuter.plan import Plan
 from pytrip.tripexecuter.projectile import Projectile
 from pytrip.tripexecuter.kernel import KernelModel
 from pytrip.tripexecuter.execparser import ExecParser
+from pytrip.tripexecuter.executor_logger import ExecutorLogger, ConsoleExecutorLogger, FileExecutorLogger
 
 # from https://docs.python.org/3/tutorial/modules.html
 # if a package's __init__.py code defines a list named __all__,
 # it is taken to be the list of module names that should be imported when from package import * is encountered.
-__all__ = ['Field', 'Execute', 'Plan', 'Projectile', 'KernelModel', 'ExecParser']
+__all__ = ['Field', 'Execute', 'Plan', 'Projectile', 'KernelModel', 'ExecParser',
+           'ExecutorLogger', 'ConsoleExecutorLogger', 'FileExecutorLogger']

--- a/pytrip/tripexecuter/execute.py
+++ b/pytrip/tripexecuter/execute.py
@@ -370,7 +370,7 @@ class Execute(object):
             logger.debug("Execute on remote server: {:s}".format(_cmd))
             self.info("Executing commands")
             self.log(_cmd.replace(";", "\n"))
-            _, stdout, stderr = ssh.exec_command(quote(_cmd), get_pty=True)
+            _, stdout, stderr = ssh.exec_command(_cmd, get_pty=True)  # skipcq: BAN-B601
 
             self.info("Result")
             for line in stdout:

--- a/pytrip/tripexecuter/executor_logger.py
+++ b/pytrip/tripexecuter/executor_logger.py
@@ -16,9 +16,7 @@
 #    You should have received a copy of the GNU General Public License
 #    along with PyTRiP98.  If not, see <http://www.gnu.org/licenses/>.
 #
-"""
-This file contains the ExecutorLogger classes which are used to log execution logs
-"""
+"""This file contains the ExecutorLogger classes which are used to log execution logs"""
 
 import logging
 

--- a/pytrip/tripexecuter/executor_logger.py
+++ b/pytrip/tripexecuter/executor_logger.py
@@ -27,16 +27,16 @@ logger = logging.getLogger(__name__)
 
 class ExecutorLogger:
     def info(self, text):
-        pass
+        pass  # interface method
 
     def log(self, text):
-        pass
+        pass  # interface method
 
     def error(self, text):
-        pass
+        pass  # interface method
 
     def end(self):
-        pass
+        pass  # interface method
 
 
 class ConsoleExecutorLogger(ExecutorLogger):

--- a/pytrip/tripexecuter/executor_logger.py
+++ b/pytrip/tripexecuter/executor_logger.py
@@ -59,6 +59,9 @@ class FileExecutorLogger(ExecutorLogger):
         self.stdout = ""
         self.stderr = ""
 
+    def info(self, text):
+        self.stdout += text + "\n"
+
     def log(self, text):
         self.stdout += text + "\n"
 

--- a/pytrip/tripexecuter/executor_logger.py
+++ b/pytrip/tripexecuter/executor_logger.py
@@ -1,0 +1,77 @@
+#
+#    Copyright (C) 2010-2021 PyTRiP98 Developers.
+#
+#    This file is part of PyTRiP98.
+#
+#    PyTRiP98 is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    PyTRiP98 is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with PyTRiP98.  If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+This file contains the ExecutorLogger classes which are used to log execution logs
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class ExecutorLogger:
+    def info(self, text):
+        pass
+
+    def log(self, text):
+        pass
+
+    def error(self, text):
+        pass
+
+    def end(self):
+        pass
+
+
+class ConsoleExecutorLogger(ExecutorLogger):
+    def info(self, text):
+        print(text)
+
+    def log(self, text):
+        print(text)
+
+    def error(self, text):
+        print(text)
+
+
+class FileExecutorLogger(ExecutorLogger):
+    def __init__(self, stdout_path, stderr_path):
+        logger.debug("Write stdout to {:s}".format(stdout_path))
+        logger.debug("Write stderr to {:s}".format(stderr_path))
+        self.stdout_path = stdout_path
+        self.stderr_path = stderr_path
+        self.stdout = ""
+        self.stderr = ""
+
+    def log(self, text):
+        self.stdout += text + "\n"
+
+    def error(self, text):
+        if self.stdout_path != self.stderr_path:
+            self.stderr += text + "\n"
+        else:
+            self.stdout += text + "\n"
+
+    def end(self):
+        with open(self.stdout_path, "w") as file:
+            file.write(self.stdout)
+
+        if self.stdout_path != self.stderr_path:
+            with open(self.stderr_path, "w") as file:
+                file.write(self.stderr)

--- a/pytrip/util.py
+++ b/pytrip/util.py
@@ -486,6 +486,27 @@ class TRiP98FileLocator(object):
         logger.warning("Checking following files: " + " , ".join(files_tried) + ". None of them exists.")
         return None
 
+def human_readable_size(num, suffix="B"):
+    # https://stackoverflow.com/questions/1094841/get-human-readable-version-of-file-size
+    for unit in ["", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei", "Zi"]:
+        if abs(num) < 1024.0:
+            number = "{:.2f}".format(num).rstrip('0').rstrip('.')
+            return "{:s}{:s}{:s}".format(number, unit, suffix)
+        num /= 1024.0
+    number = "{:.2f}".format(num).rstrip('0').rstrip('.')
+    return "{:s}Yi{:s}".format(number, suffix)
+
+def get_size(start_path="."):
+    # https://stackoverflow.com/questions/1392413/calculating-a-directorys-size-using-python
+    total_size = 0
+    for dirpath, dirnames, filenames in os.walk(start_path):
+        for f in filenames:
+            fp = os.path.join(dirpath, f)
+            # skip if it is symbolic link
+            if not os.path.islink(fp):
+                total_size += os.path.getsize(fp)
+
+    return total_size
 
 def evaluator(funct, name='funct'):
     """ Wrapper for evaluating a function.

--- a/pytrip/util.py
+++ b/pytrip/util.py
@@ -486,7 +486,15 @@ class TRiP98FileLocator(object):
         logger.warning("Checking following files: " + " , ".join(files_tried) + ". None of them exists.")
         return None
 
+
 def human_readable_size(num, suffix="B"):
+    """
+    Convert number of bytes to human readable form
+    for example 35489 -> 34.66KiB
+    :param num: number of bytes to convert
+    :param suffix: suffix to use (default B (byte))
+    :return: string with number in human readable form
+    """
     # https://stackoverflow.com/questions/1094841/get-human-readable-version-of-file-size
     for unit in ["", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei", "Zi"]:
         if abs(num) < 1024.0:
@@ -496,10 +504,16 @@ def human_readable_size(num, suffix="B"):
     number = "{:.2f}".format(num).rstrip('0').rstrip('.')
     return "{:s}Yi{:s}".format(number, suffix)
 
+
 def get_size(start_path="."):
+    """
+    Calculates size of directory (with subdirectories)
+    :param start_path: path to directory
+    :return: size of directory in bytes
+    """
     # https://stackoverflow.com/questions/1392413/calculating-a-directorys-size-using-python
     total_size = 0
-    for dirpath, dirnames, filenames in os.walk(start_path):
+    for dirpath, _, filenames in os.walk(start_path):
         for f in filenames:
             fp = os.path.join(dirpath, f)
             # skip if it is symbolic link
@@ -507,6 +521,7 @@ def get_size(start_path="."):
                 total_size += os.path.getsize(fp)
 
     return total_size
+
 
 def evaluator(funct, name='funct'):
     """ Wrapper for evaluating a function.


### PR DESCRIPTION
changes:
- real time remote logs
- ExecutorLoggers
- information about compressing, extracting and transferring in remote
- information about executing TRiP98 (remote and local)
- fix bug that was causing crash of execute sometimes (reason: using rstrip instead of splitext)
- remove os.chdir calls

associated with pytrip/pytripgui#365
associated with pytrip/pytripgui#366
associated with pytrip/pytripgui#510