### PR TITLE
deepsource fixes

### DIFF
--- a/pytrip/ctx.py
+++ b/pytrip/ctx.py
@@ -61,8 +61,8 @@ class CtxCube(Cube):
         intersect = float(dcm["images"][0].RescaleIntercept)
         slope = float(dcm["images"][0].RescaleSlope)
 
-        for i in range(len(dcm["images"])):
-            data = np.array(dcm["images"][i].pixel_array) * slope + intersect
+        for i, dcm_image in enumerate(dcm["images"]):
+            data = np.array(dcm_image.pixel_array) * slope + intersect
             self.cube[i][:][:] = data
         if len(self.slice_pos) > 1 and self.slice_pos[1] < self.slice_pos[0]:
             self.slice_pos.reverse()
@@ -111,7 +111,7 @@ class CtxCube(Cube):
         ds.AcquisitionNumber = '1'  # AcquisitionNumber tag 0x0020, 0x0012 (type IS - Integer String)
 
         import uuid
-        for i in range(len(self.cube)):
+        for i, cube in enumerate(self.cube):
             _ds = copy.deepcopy(ds)
             _ds.ImagePositionPatient = ["{:.3f}".format(self.xoffset),
                                         "{:.3f}".format(self.yoffset),
@@ -138,7 +138,7 @@ class CtxCube(Cube):
             _ds.SliceLocation = str(self.slice_pos[i])
             _ds.InstanceNumber = str(i + 1)
             pixel_array = np.zeros((_ds.Rows, _ds.Columns), dtype=self.pydata_type)
-            pixel_array[:][:] = self.cube[i][:][:]
+            pixel_array[:][:] = cube[:][:]
             _ds.PixelData = pixel_array.tostring()
             data.append(_ds)
         return data

--- a/pytrip/cube.py
+++ b/pytrip/cube.py
@@ -462,7 +462,7 @@ class Cube(object):
             # i.e. read( ("1.hed", "2.dos"), what about basename then ?
 
         else:
-            raise Exception("More than two arguments provided as path variable to Cube.read method")
+            raise ValueError("More than two arguments provided as path variable to Cube.read method")
 
         # finally read files
         self._read_trip_header_file(header_path=header_path)
@@ -693,7 +693,7 @@ class Cube(object):
             if not TRiP98FilePath(datafile_path, self).is_valid_datafile_path():
                 logger.warning("Loading {:s} which doesn't look like valid datafile path".format(datafile_path))
         else:
-            raise Exception("More than two arguments provided as path variable to Cube.read method")
+            raise ValueError("More than two arguments provided as path variable to Cube.write method")
 
         # finally write files
         self._write_trip_header(header_path)

--- a/pytrip/ddd.py
+++ b/pytrip/ddd.py
@@ -30,8 +30,6 @@ logger = logging.getLogger(__name__)
 class DDD:
     """ Class for handling Depth-Dose Data.
     """
-    def __init__(self):
-        pass
 
     def get_ddd_data(self, energy, points):
         """ TODO: documentation
@@ -123,11 +121,13 @@ class DDD:
             with open(item, 'r') as f:
                 data = f.read()
             lines = data.split('\n')
-            for n, line in enumerate(data.split("\n")):
+            n = 0
+            for line in lines:
                 if line.find("energy") != -1:
                     energy = float(line.split()[1])
                 if line.find('!') == -1 and line.find('#') == -1:
                     break
+                n += 1
             for i in range(n, len(lines)):
                 if len(lines[i]) < 3:
                     continue

--- a/pytrip/dos.py
+++ b/pytrip/dos.py
@@ -110,10 +110,10 @@ class DosCube(Cube):
         voi_and_cube_intersect = False
         for i in range(self.dimz):
             z_pos += self.slice_distance
-            slice = voi.get_slice_at_pos(z_pos)
-            if slice is not None:  # VOI intersects with this slice
+            slice_at_pos = voi.get_slice_at_pos(z_pos)
+            if slice_at_pos is not None:  # VOI intersects with this slice
                 voi_and_cube_intersect = True
-                contour_array = np.array(slice.contours[0].contour)
+                contour_array = np.array(slice_at_pos.contours[0].contour)
                 dose_bins += pytriplib.calculate_dvh_slice(self.cube[i], contour_array, voxel_size)
 
         if voi_and_cube_intersect:
@@ -158,8 +158,7 @@ class DosCube(Cube):
         if dvh_tuple is None:
             logging.warning("Voi {:s} outside the cube".format(voi.get_name()))
         else:
-            dvh, min_dose, max_dose, mean_dose, mean_volume = dvh_tuple
-            np.savetxt(dvh, filename)
+            np.savetxt(dvh_tuple[0], filename)
 
     def create_dicom_plan(self):
         """ Create a dummy DICOM RT-plan object.

--- a/pytrip/field.py
+++ b/pytrip/field.py
@@ -111,7 +111,7 @@ class SubField:
         self.ddd = ddd
 
     def get_lateral(self, resolution=0.5):
-        if hasattr(self, "lateral") and resolution == resolution:
+        if hasattr(self, "lateral"):
             return self.lateral
         max_dist = self.get_max_dist()
         dim = np.ceil(np.absolute(max_dist / resolution))

--- a/pytrip/let.py
+++ b/pytrip/let.py
@@ -83,9 +83,9 @@ class LETCube(Cube):
         lv = np.zeros(3000)
         for i in range(self.dimz):
             pos += self.slice_distance
-            slice = voi.get_slice_at_pos(pos)
-            if slice is not None:
-                lv += pytriplib.calculate_lvh_slice(self.cube[i], np.array(slice.contours[0].contour), size)
+            slice_at_pos = voi.get_slice_at_pos(pos)
+            if slice_at_pos is not None:
+                lv += pytriplib.calculate_lvh_slice(self.cube[i], np.array(slice_at_pos.contours[0].contour), size)
 
         cubes = sum(lv)
         lvh = np.cumsum(lv[::-1])[::-1] / cubes
@@ -109,6 +109,5 @@ class LETCube(Cube):
         # see calculate_lvh() method
         for vol, let in zip(lvh[0], lvh[1]):
             output += "%.4e\t%.4e\n" % (vol, let)
-        f = open(path + ".dvh", "w+")
-        f.write(output)
-        f.close()
+        with open(path + ".dvh", "w+") as f:
+            f.write(output)

--- a/pytrip/raster.py
+++ b/pytrip/raster.py
@@ -81,13 +81,13 @@ class Rst:
         with open(path, mode='r') as f:
             data = f.read()
         data = data.split("\n")
-        out, i = parse_to_var(data, self.var_dict, "submachine#")
+        out, i = parse_to_var(data, self.var_dict, stoptag="submachine#")
 
         for key, item in out.items():
             setattr(self, key, item)
         if hasattr(self, "bolus"):
             self.bolus = float(self.bolus)
-        for machine in range(int(self.submachines)):
+        for _ in range(int(self.submachines)):
             submachine = SubMachine()
             i = submachine._parse_submachine(data, i)
             self.machines.append(submachine)
@@ -292,7 +292,7 @@ class SubMachine:
                 self.max_particles = line.split()[2]
                 self.total_particles = line.split()[3]
         i += 1
-        for i in range(i, i + self.points):
-            items = data[i].split()
+        for j in range(i, i + self.points):
+            items = data[j].split()
             self.raster_points.append([float(items[0]), float(items[1]), float(items[2])])
-        return i + 1
+        return i + self.points

--- a/pytrip/res/concave_tool.py
+++ b/pytrip/res/concave_tool.py
@@ -1,4 +1,21 @@
-import math
+#
+#    Copyright (C) 2010-2021 PyTRiP98 Developers.
+#
+#    This file is part of PyTRiP98.
+#
+#    PyTRiP98 is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    PyTRiP98 is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with PyTRiP98.  If not, see <http://www.gnu.org/licenses/>.
+#
 """
 This file contains methods that create from a list of intersections (list of points).
 Algorithm steps:
@@ -13,6 +30,8 @@ Basic heuristics are used:
     2. limiting distance between parts and points based on previous distances
         (next point cannot be too far away from parts)
 """
+
+import math
 
 
 class ListEntry:

--- a/pytrip/res/interpolate.py
+++ b/pytrip/res/interpolate.py
@@ -144,8 +144,7 @@ class RegularInterpolator(object):
         """
         if y is None:
             return self._interp_function(x)
-        else:
-            return self._interp_function(x, y, grid=False)
+        return self._interp_function(x, y, grid=False)
 
     @classmethod
     def eval(cls, x, y=None, xp=None, yp=None, zp=None, kind='linear'):
@@ -229,7 +228,7 @@ class RegularInterpolator(object):
             elif kind == 'linear':
                 result = fun_interp
             else:
-                raise ("Unsupported interpolation type {:s}.".format(kind))
+                raise Exception("Unsupported interpolation type {:s}.".format(kind))
         return result
 
     @staticmethod

--- a/pytrip/res/interpolate.py
+++ b/pytrip/res/interpolate.py
@@ -228,7 +228,7 @@ class RegularInterpolator(object):
             elif kind == 'linear':
                 result = fun_interp
             else:
-                raise Exception("Unsupported interpolation type {:s}.".format(kind))
+                raise ValueError("Unsupported interpolation type {:s}.".format(kind))
         return result
 
     @staticmethod

--- a/pytrip/res/point.py
+++ b/pytrip/res/point.py
@@ -59,9 +59,7 @@ def point_in_polygon(x, y, polygon):
         x2 = polygon[i % n][0]
         y2 = polygon[i % n][1]
         if min(y1, y2) < y <= max(y1, y2) and x <= max(x1, x2):
-            xinters = None
-            if y1 != y2:
-                xinters = (y - y1) * (x2 - x1) / (y2 - y1) + x1
+            xinters = (y - y1) * (x2 - x1) / (y2 - y1) + x1
             if x1 == x2 or x <= xinters:
                 intersects += 1
         x1 = x2

--- a/pytrip/res/point.py
+++ b/pytrip/res/point.py
@@ -58,13 +58,12 @@ def point_in_polygon(x, y, polygon):
     for i in range(n + 1):
         x2 = polygon[i % n][0]
         y2 = polygon[i % n][1]
-        if y > min(y1, y2):
-            if y <= max(y1, y2):
-                if x <= max(x1, x2):
-                    if y1 != y2:
-                        xinters = (y - y1) * (x2 - x1) / (y2 - y1) + x1
-                    if x1 == x2 or x <= xinters:
-                        intersects += 1
+        if min(y1, y2) < y <= max(y1, y2) and x <= max(x1, x2):
+            xinters = None
+            if y1 != y2:
+                xinters = (y - y1) * (x2 - x1) / (y2 - y1) + x1
+            if x1 == x2 or x <= xinters:
+                intersects += 1
         x1 = x2
         y1 = y2
     return intersects % 2 != 0
@@ -126,10 +125,9 @@ def get_x_intersection(y, polygon):
         x2 = polygon[i % n][0]  # modulus operator will make last point to 0, i.e. start index.
         y2 = polygon[i % n][1]
         # test if y is between y1 and y2
-        if y > min(y1, y2):
-            if y <= max(y1, y2):
-                x = (x2 - x1) / (y2 - y1) * (y - y1) + x1
-                intersections.append(x)
+        if min(y1, y2) < y <= max(y1, y2):
+            x = (x2 - x1) / (y2 - y1) * (y - y1) + x1
+            intersections.append(x)
         x1 = x2
         y1 = y2
     return intersections

--- a/pytrip/spc.py
+++ b/pytrip/spc.py
@@ -97,289 +97,287 @@ class SPC(object):
                                                                   tt=self.targname,
                                                                   uuu="MeV",
                                                                   eeeee=int(100 * self.energy))
-        fd = open(fname, "wb")
+        with open(fname, "wb") as fd:
 
-        # filetype 1
-        # <filetype> is an 80-byte ASCII character string starting with "SPCM" or "SPCI",
-        # specifying big ("Motorola") or little ("Intel") endian byte order, respectively.
-        tag = Tag(fd)
-        tag.code = SPCTagCode.FILETYPE.value
-        tag.size = 80
-        tag.endian = self.endian
-        tag.set_tag()
-        fd.write(np.asarray(self.filetype, dtype="{:s}a{:d}".format(tag._ste, tag.size)))
-
-        # fileversion 2
-        # <fileversion> is an 80-byte ASCII character string specifying the file format version as yyyymmdd.
-        # 19980704 is the "classic" format (fixed energy range),
-        # whereas 20020107 is reserved for future possible variable energy range.
-        tag = Tag(fd)
-        tag.code = SPCTagCode.FILEVERSION.value
-        tag.size = 80
-        tag.endian = self.endian
-        tag.set_tag()
-        fd.write(np.asarray(self.fileversion, dtype="{:s}a{:d}".format(tag._ste, tag.size)))
-
-        # filedate 3
-        # <filedate> is an 80-byte ASCII character string with the file creation date
-        # as returned by the ctime() function. (<dow> <mmm> <dd> <hh>:<mm>:<ss> <yyyy>)
-        tag = Tag(fd)
-        tag.code = SPCTagCode.FILEDATE.value
-        tag.size = 80
-        tag.endian = self.endian
-        tag.set_tag()
-        fd.write(np.asarray(self.filedate, dtype="{:s}a{:d}".format(tag._ste, tag.size)))
-
-        # targname 4, projname 5
-        # <targname> and <projname> are the names of target ("H2O") and projectile ("12C6"), respectively.
-        # Since both can have any length, they are padded to the right with binary zeroes
-        # up to the next 8-byte boundary.
-        tag = Tag(fd)
-        tag.code = SPCTagCode.TARGNAME.value
-        tag.size = 8  # TODO to be padded
-        tag.endian = self.endian
-        tag.set_tag()
-        fd.write(np.asarray(self.targname, dtype="{:s}a{:d}".format(tag._ste, tag.size)))
-
-        tag = Tag(fd)
-        tag.code = SPCTagCode.PROJNAME.value
-        tag.size = 8  # TODO to be padded
-        tag.endian = self.endian
-        tag.set_tag()
-        fd.write(np.asarray(self.projname, dtype="{:s}a{:d}".format(tag._ste, tag.size)))
-
-        # no 6 double; beam energy [MeV/u]
-        tag = Tag(fd)
-        tag.code = SPCTagCode.BEAM_ENERGY.value
-        tag.size = 8
-        tag.endian = self.endian
-        tag.set_tag()
-        fd.write(np.asarray(self.energy, dtype="{:s}f{:d}".format(tag._ste, tag.size)))
-
-        # no 7, double; peak position [g/cm**2]
-        tag = Tag(fd)
-        tag.code = SPCTagCode.PEAK_POSITION.value
-        tag.size = 8
-        tag.endian = self.endian
-        tag.set_tag()
-        fd.write(np.asarray(self.peakpos, dtype="{:s}f{:d}".format(tag._ste, tag.size)))
-
-        # no 8, double; normalization, usually =1
-        tag = Tag(fd)
-        tag.code = SPCTagCode.NORMALIZATION.value
-        tag.size = 8
-        tag.endian = self.endian
-        tag.set_tag()
-        fd.write(np.asarray(self.norm, dtype="{:s}f{:d}".format(tag._ste, tag.size)))
-
-        # no 9, 8-byte unsigned integer; number of depth steps.
-        tag = Tag(fd)
-        tag.code = SPCTagCode.NO_OF_DEPTH_STEPS.value
-        tag.size = 8
-        tag.endian = self.endian
-        tag.set_tag()
-        fd.write(np.asarray(self.ndsteps, dtype="{:s}i{:d}".format(tag._ste, tag.size)))
-
-        for dblock in self.data:
-            # no 10, double; depth [g/cm**2]
+            # filetype 1
+            # <filetype> is an 80-byte ASCII character string starting with "SPCM" or "SPCI",
+            # specifying big ("Motorola") or little ("Intel") endian byte order, respectively.
             tag = Tag(fd)
-            tag.code = SPCTagCode.DEPTH.value
+            tag.code = SPCTagCode.FILETYPE.value
+            tag.size = 80
+            tag.endian = self.endian
+            tag.set_tag()
+            fd.write(np.asarray(self.filetype, dtype="{:s}a{:d}".format(tag._ste, tag.size)))
+
+            # fileversion 2
+            # <fileversion> is an 80-byte ASCII character string specifying the file format version as yyyymmdd.
+            # 19980704 is the "classic" format (fixed energy range),
+            # whereas 20020107 is reserved for future possible variable energy range.
+            tag = Tag(fd)
+            tag.code = SPCTagCode.FILEVERSION.value
+            tag.size = 80
+            tag.endian = self.endian
+            tag.set_tag()
+            fd.write(np.asarray(self.fileversion, dtype="{:s}a{:d}".format(tag._ste, tag.size)))
+
+            # filedate 3
+            # <filedate> is an 80-byte ASCII character string with the file creation date
+            # as returned by the ctime() function. (<dow> <mmm> <dd> <hh>:<mm>:<ss> <yyyy>)
+            tag = Tag(fd)
+            tag.code = SPCTagCode.FILEDATE.value
+            tag.size = 80
+            tag.endian = self.endian
+            tag.set_tag()
+            fd.write(np.asarray(self.filedate, dtype="{:s}a{:d}".format(tag._ste, tag.size)))
+
+            # targname 4, projname 5
+            # <targname> and <projname> are the names of target ("H2O") and projectile ("12C6"), respectively.
+            # Since both can have any length, they are padded to the right with binary zeroes
+            # up to the next 8-byte boundary.
+            tag = Tag(fd)
+            tag.code = SPCTagCode.TARGNAME.value
+            tag.size = 8  # TODO to be padded
+            tag.endian = self.endian
+            tag.set_tag()
+            fd.write(np.asarray(self.targname, dtype="{:s}a{:d}".format(tag._ste, tag.size)))
+
+            tag = Tag(fd)
+            tag.code = SPCTagCode.PROJNAME.value
+            tag.size = 8  # TODO to be padded
+            tag.endian = self.endian
+            tag.set_tag()
+            fd.write(np.asarray(self.projname, dtype="{:s}a{:d}".format(tag._ste, tag.size)))
+
+            # no 6 double; beam energy [MeV/u]
+            tag = Tag(fd)
+            tag.code = SPCTagCode.BEAM_ENERGY.value
             tag.size = 8
             tag.endian = self.endian
             tag.set_tag()
-            fd.write(np.asarray(dblock.depth, dtype="{:s}f{:d}".format(tag._ste, tag.size)))
+            fd.write(np.asarray(self.energy, dtype="{:s}f{:d}".format(tag._ste, tag.size)))
 
-            # no 11, double; normalization for this depth step, usually =1.
+            # no 7, double; peak position [g/cm**2]
             tag = Tag(fd)
-            tag.code = SPCTagCode.DEPTH_STEP_NORMALIZATION.value
+            tag.code = SPCTagCode.PEAK_POSITION.value
             tag.size = 8
             tag.endian = self.endian
             tag.set_tag()
-            fd.write(np.asarray(dblock.dsnorm, dtype="{:s}f{:d}".format(tag._ste, tag.size)))
+            fd.write(np.asarray(self.peakpos, dtype="{:s}f{:d}".format(tag._ste, tag.size)))
 
-            # no 12, 8-byte unsigned integer; number of particle species.
+            # no 8, double; normalization, usually =1
             tag = Tag(fd)
-            tag.code = SPCTagCode.NO_OF_PARTICLE_SPECIES.value
+            tag.code = SPCTagCode.NORMALIZATION.value
             tag.size = 8
             tag.endian = self.endian
             tag.set_tag()
-            fd.write(np.asarray(dblock.nparts, dtype="{:s}u{:d}".format(tag._ste, tag.size)))
+            fd.write(np.asarray(self.norm, dtype="{:s}f{:d}".format(tag._ste, tag.size)))
 
-            ebins = {}
+            # no 9, 8-byte unsigned integer; number of depth steps.
+            tag = Tag(fd)
+            tag.code = SPCTagCode.NO_OF_DEPTH_STEPS.value
+            tag.size = 8
+            tag.endian = self.endian
+            tag.set_tag()
+            fd.write(np.asarray(self.ndsteps, dtype="{:s}i{:d}".format(tag._ste, tag.size)))
 
-            for specie_item_no, specie in enumerate(dblock.species):
-                # no 13, double Z, double A, long Z, long A;
+            for dblock in self.data:
+                # no 10, double; depth [g/cm**2]
                 tag = Tag(fd)
-                tag.code = SPCTagCode.ZA.value
-                tag.size = 24
-                tag.endian = self.endian
-                tag.set_tag()
-                fd.write(np.asarray([specie.z, specie.a], dtype="{:s}f8".format(tag._ste)))
-                fd.write(np.asarray([specie.lz, specie.la], dtype="{:s}u4".format(tag._ste)))
-
-                # no 14, double
-                # The scalar Cum value is the cumulated number (running sum) of fragments,
-                # i.e. the species sum over Cum[nE].
-                # This number may exceed 1, since for an incoming primary particle many secondaries are created.
-                tag = Tag(fd)
-                tag.code = SPCTagCode.CUMULATED_NO_OF_FRAGMENTS.value
+                tag.code = SPCTagCode.DEPTH.value
                 tag.size = 8
                 tag.endian = self.endian
                 tag.set_tag()
-                fd.write(np.asarray([specie.dscum], dtype="{:s}f{:d}".format(tag._ste, tag.size)))
-
-                # no 15, 8-byte unsigned integer;
-                # <nC> is reserved for later use, so that lateral scattering for each fragment can be included.
-                # At present nC=0.
-                tag = Tag(fd)
-                tag.code = SPCTagCode.NC.value
-                tag.size = 8
-                tag.endian = self.endian
-                tag.set_tag()
-                fd.write(np.asarray([specie.nc], dtype="{:s}u{:d}".format(tag._ste, tag.size)))
-
-                # no 16, 8-byte unsigned integer;
-                # 8-byte unsigned integer; number of energy bins for this species
-                tag = Tag(fd)
-                tag.code = SPCTagCode.NO_OF_ENERGY_BINS.value
-                tag.size = 8
-                tag.endian = self.endian
-                tag.set_tag()
-                fd.write(np.asarray([specie.ne], dtype="{:s}u{:d}".format(tag._ste, tag.size)))
-
-                # If a species data block is flagged as EREFCOPY, its energy bins are not stored,
-                # but rather a reference index <lSRef> (0..<nS>-1) to a species with identical energy binning.
-                # This helps to reduce space requirements, since fragment spectra may share the same energy bins.
-                # If the energy bins for the species under consideration are not a reference copy,
-                # <nE>+1 double precision bin border values are stored.
-                compatible_ebins_index = [i for i in ebins if np.array_equal(specie.ebindata, ebins[i])]
-                if not compatible_ebins_index:
-                    ebins[specie_item_no] = specie.ebindata
-
-                    # no 17, double; energy bin values
-                    tag = Tag(fd)
-                    tag.code = SPCTagCode.ENERGY_BIN_VALUES.value
-                    tag.size = 8 * (specie.ne + 1)
-                    tag.endian = self.endian
-                    tag.set_tag()
-                    fd.write(np.asarray(specie.ebindata, dtype="{:s}f8".format(tag._ste)))
-                else:
-                    # no 18,  8-byte unsigned integer
-                    tag = Tag(fd)
-                    tag.code = SPCTagCode.ENERGY_BIN_POINTER.value
-                    tag.size = 8
-                    tag.endian = self.endian
-                    tag.set_tag()
-                    fd.write(np.asarray([compatible_ebins_index[0]], dtype="{:s}u{:d}".format(tag._ste, tag.size)))
-
-                # no 19,  double; spectrum bin values
-                tag = Tag(fd)
-                tag.code = SPCTagCode.SPECTRUM_BIN_VALUES.value
-                tag.size = 8 * specie.ne
-                tag.endian = self.endian
-                tag.set_tag()
-                fd.write(np.asarray(specie.histdata, dtype="{:s}f8".format(tag._ste)))
-
-                # no 20,  double; running cumulated spectrum bin values
-                tag = Tag(fd)
-                tag.code = SPCTagCode.CUMULATED_SPECTRUM_BIN_VALUES.value
-                tag.size = 8 * (specie.ne + 1)
-                tag.endian = self.endian
-                tag.set_tag()
-                fd.write(np.asarray(specie.rcumdata, dtype="{:s}f8".format(tag._ste)))
-
-        fd.close()
-
-    def read_data(self):
-        fd = open(self.filename, "rb")
-        t = Tag(fd)
-        db = []
-
-        while t.code < SPCTagCode.NO_OF_DEPTH_STEPS.value:
-            t.get_tag()
-            self.endian = t.endian
-            pl = self.get_payload(fd, t)
-
-        for i in range(self.ndsteps):
-            # no 10, double; depth [g/cm**2]
-            t.get_tag()
-            pl = self.get_payload(fd, t)
-
-            # construct the main object
-            if t.code == SPCTagCode.DEPTH.value:
-                db.append(DBlock())
-                db[-1].depth = pl
+                fd.write(np.asarray(dblock.depth, dtype="{:s}f{:d}".format(tag._ste, tag.size)))
 
                 # no 11, double; normalization for this depth step, usually =1.
-                t.get_tag()
-                if t.code == SPCTagCode.DEPTH_STEP_NORMALIZATION.value:
-                    pl = self.get_payload(fd, t)
-                    db[-1].dsnorm = pl
+                tag = Tag(fd)
+                tag.code = SPCTagCode.DEPTH_STEP_NORMALIZATION.value
+                tag.size = 8
+                tag.endian = self.endian
+                tag.set_tag()
+                fd.write(np.asarray(dblock.dsnorm, dtype="{:s}f{:d}".format(tag._ste, tag.size)))
 
                 # no 12, 8-byte unsigned integer; number of particle species.
-                t.get_tag()
-                if t.code == SPCTagCode.NO_OF_PARTICLE_SPECIES.value:
-                    pl = self.get_payload(fd, t)
-                    db[-1].nparts = pl
+                tag = Tag(fd)
+                tag.code = SPCTagCode.NO_OF_PARTICLE_SPECIES.value
+                tag.size = 8
+                tag.endian = self.endian
+                tag.set_tag()
+                fd.write(np.asarray(dblock.nparts, dtype="{:s}u{:d}".format(tag._ste, tag.size)))
 
-                for j in range(db[-1].nparts):  # loop over all species
+                ebins = {}
+
+                for specie_item_no, specie in enumerate(dblock.species):
                     # no 13, double Z, double A, long Z, long A;
-                    t.get_tag()
-                    if t.code == SPCTagCode.ZA.value:
-                        pl = self.get_payload(fd, t)
-                        db[-1].species.append(SBlock())
-                        db[-1].species[-1].z = pl[0]
-                        db[-1].species[-1].a = pl[1]
-                        db[-1].species[-1].lz = int(pl[2])
-                        db[-1].species[-1].la = int(pl[3])
+                    tag = Tag(fd)
+                    tag.code = SPCTagCode.ZA.value
+                    tag.size = 24
+                    tag.endian = self.endian
+                    tag.set_tag()
+                    fd.write(np.asarray([specie.z, specie.a], dtype="{:s}f8".format(tag._ste)))
+                    fd.write(np.asarray([specie.lz, specie.la], dtype="{:s}u4".format(tag._ste)))
 
                     # no 14, double
                     # The scalar Cum value is the cumulated number (running sum) of fragments,
                     # i.e. the species sum over Cum[nE].
                     # This number may exceed 1, since for an incoming primary particle many secondaries are created.
-                    t.get_tag()
-                    if t.code == SPCTagCode.CUMULATED_NO_OF_FRAGMENTS.value:
-                        pl = self.get_payload(fd, t)
-                        db[-1].species[-1].dscum = pl
+                    tag = Tag(fd)
+                    tag.code = SPCTagCode.CUMULATED_NO_OF_FRAGMENTS.value
+                    tag.size = 8
+                    tag.endian = self.endian
+                    tag.set_tag()
+                    fd.write(np.asarray([specie.dscum], dtype="{:s}f{:d}".format(tag._ste, tag.size)))
 
                     # no 15, 8-byte unsigned integer;
                     # <nC> is reserved for later use, so that lateral scattering for each fragment can be included.
                     # At present nC=0.
-                    t.get_tag()
-                    if t.code == SPCTagCode.NC.value:
-                        pl = self.get_payload(fd, t)
-                        db[-1].species[-1].nc = pl
+                    tag = Tag(fd)
+                    tag.code = SPCTagCode.NC.value
+                    tag.size = 8
+                    tag.endian = self.endian
+                    tag.set_tag()
+                    fd.write(np.asarray([specie.nc], dtype="{:s}u{:d}".format(tag._ste, tag.size)))
 
                     # no 16, 8-byte unsigned integer;
                     # 8-byte unsigned integer; number of energy bins for this species
-                    t.get_tag()
-                    if t.code == SPCTagCode.NO_OF_ENERGY_BINS.value:
-                        pl = self.get_payload(fd, t)
-                        db[-1].species[-1].ne = pl
+                    tag = Tag(fd)
+                    tag.code = SPCTagCode.NO_OF_ENERGY_BINS.value
+                    tag.size = 8
+                    tag.endian = self.endian
+                    tag.set_tag()
+                    fd.write(np.asarray([specie.ne], dtype="{:s}u{:d}".format(tag._ste, tag.size)))
 
-                    # no 17, double; energy bin values
-                    t.get_tag()
-                    if t.code == SPCTagCode.ENERGY_BIN_VALUES.value:
-                        pl = self.get_payload(fd, t)
-                        db[-1].species[-1].ebindata = pl
-                    # no 18,  8-byte unsigned integer
-                    if t.code == SPCTagCode.ENERGY_BIN_POINTER.value:  # both tags will not be present
-                        pl = self.get_payload(fd, t)
-                        db[-1].species[-1].ebindata = db[0].species[pl].ebindata
+                    # If a species data block is flagged as EREFCOPY, its energy bins are not stored,
+                    # but rather a reference index <lSRef> (0..<nS>-1) to a species with identical energy binning.
+                    # This helps to reduce space requirements, since fragment spectra may share the same energy bins.
+                    # If the energy bins for the species under consideration are not a reference copy,
+                    # <nE>+1 double precision bin border values are stored.
+                    compatible_ebins_index = [i for i in ebins if np.array_equal(specie.ebindata, ebins[i])]
+                    if not compatible_ebins_index:
+                        ebins[specie_item_no] = specie.ebindata
+
+                        # no 17, double; energy bin values
+                        tag = Tag(fd)
+                        tag.code = SPCTagCode.ENERGY_BIN_VALUES.value
+                        tag.size = 8 * (specie.ne + 1)
+                        tag.endian = self.endian
+                        tag.set_tag()
+                        fd.write(np.asarray(specie.ebindata, dtype="{:s}f8".format(tag._ste)))
+                    else:
+                        # no 18,  8-byte unsigned integer
+                        tag = Tag(fd)
+                        tag.code = SPCTagCode.ENERGY_BIN_POINTER.value
+                        tag.size = 8
+                        tag.endian = self.endian
+                        tag.set_tag()
+                        fd.write(np.asarray([compatible_ebins_index[0]], dtype="{:s}u{:d}".format(tag._ste, tag.size)))
 
                     # no 19,  double; spectrum bin values
-                    t.get_tag()
-                    if t.code == SPCTagCode.SPECTRUM_BIN_VALUES.value:
-                        pl = self.get_payload(fd, t)
-                        db[-1].species[-1].histdata = pl
+                    tag = Tag(fd)
+                    tag.code = SPCTagCode.SPECTRUM_BIN_VALUES.value
+                    tag.size = 8 * specie.ne
+                    tag.endian = self.endian
+                    tag.set_tag()
+                    fd.write(np.asarray(specie.histdata, dtype="{:s}f8".format(tag._ste)))
 
                     # no 20,  double; running cumulated spectrum bin values
-                    t.get_tag()
-                    if t.code == SPCTagCode.CUMULATED_SPECTRUM_BIN_VALUES.value:
-                        pl = self.get_payload(fd, t)
-                        db[-1].species[-1].rcumdata = pl
+                    tag = Tag(fd)
+                    tag.code = SPCTagCode.CUMULATED_SPECTRUM_BIN_VALUES.value
+                    tag.size = 8 * (specie.ne + 1)
+                    tag.endian = self.endian
+                    tag.set_tag()
+                    fd.write(np.asarray(specie.rcumdata, dtype="{:s}f8".format(tag._ste)))
 
-            self.data = db
+    def read_data(self):
+        with open(self.filedate, "rb") as fd:
+            t = Tag(fd)
+            db = []
+
+            while t.code < SPCTagCode.NO_OF_DEPTH_STEPS.value:
+                t.get_tag()
+                self.endian = t.endian
+                pl = self.get_payload(fd, t)
+
+            for _ in range(self.ndsteps):
+                # no 10, double; depth [g/cm**2]
+                t.get_tag()
+                pl = self.get_payload(fd, t)
+
+                # construct the main object
+                if t.code == SPCTagCode.DEPTH.value:
+                    db.append(DBlock())
+                    db[-1].depth = pl
+
+                    # no 11, double; normalization for this depth step, usually =1.
+                    t.get_tag()
+                    if t.code == SPCTagCode.DEPTH_STEP_NORMALIZATION.value:
+                        pl = self.get_payload(fd, t)
+                        db[-1].dsnorm = pl
+
+                    # no 12, 8-byte unsigned integer; number of particle species.
+                    t.get_tag()
+                    if t.code == SPCTagCode.NO_OF_PARTICLE_SPECIES.value:
+                        pl = self.get_payload(fd, t)
+                        db[-1].nparts = pl
+
+                    for _ in range(db[-1].nparts):  # loop over all species
+                        # no 13, double Z, double A, long Z, long A;
+                        t.get_tag()
+                        if t.code == SPCTagCode.ZA.value:
+                            pl = self.get_payload(fd, t)
+                            db[-1].species.append(SBlock())
+                            db[-1].species[-1].z = pl[0]
+                            db[-1].species[-1].a = pl[1]
+                            db[-1].species[-1].lz = int(pl[2])
+                            db[-1].species[-1].la = int(pl[3])
+
+                        # no 14, double
+                        # The scalar Cum value is the cumulated number (running sum) of fragments,
+                        # i.e. the species sum over Cum[nE].
+                        # This number may exceed 1, since for an incoming primary particle many secondaries are created.
+                        t.get_tag()
+                        if t.code == SPCTagCode.CUMULATED_NO_OF_FRAGMENTS.value:
+                            pl = self.get_payload(fd, t)
+                            db[-1].species[-1].dscum = pl
+
+                        # no 15, 8-byte unsigned integer;
+                        # <nC> is reserved for later use, so that lateral scattering for each fragment can be included.
+                        # At present nC=0.
+                        t.get_tag()
+                        if t.code == SPCTagCode.NC.value:
+                            pl = self.get_payload(fd, t)
+                            db[-1].species[-1].nc = pl
+
+                        # no 16, 8-byte unsigned integer;
+                        # 8-byte unsigned integer; number of energy bins for this species
+                        t.get_tag()
+                        if t.code == SPCTagCode.NO_OF_ENERGY_BINS.value:
+                            pl = self.get_payload(fd, t)
+                            db[-1].species[-1].ne = pl
+
+                        # no 17, double; energy bin values
+                        t.get_tag()
+                        if t.code == SPCTagCode.ENERGY_BIN_VALUES.value:
+                            pl = self.get_payload(fd, t)
+                            db[-1].species[-1].ebindata = pl
+                        # no 18,  8-byte unsigned integer
+                        if t.code == SPCTagCode.ENERGY_BIN_POINTER.value:  # both tags will not be present
+                            pl = self.get_payload(fd, t)
+                            db[-1].species[-1].ebindata = db[0].species[pl].ebindata
+
+                        # no 19,  double; spectrum bin values
+                        t.get_tag()
+                        if t.code == SPCTagCode.SPECTRUM_BIN_VALUES.value:
+                            pl = self.get_payload(fd, t)
+                            db[-1].species[-1].histdata = pl
+
+                        # no 20,  double; running cumulated spectrum bin values
+                        t.get_tag()
+                        if t.code == SPCTagCode.CUMULATED_SPECTRUM_BIN_VALUES.value:
+                            pl = self.get_payload(fd, t)
+                            db[-1].species[-1].rcumdata = pl
+
+                self.data = db
 
     def get_payload(self, fd, tag):
         cnt = 1
@@ -557,6 +555,8 @@ class SPC(object):
             payload = np.fromfile(fd, count=cnt, dtype=np.dtype(sdtype))
             # self.cum = payload
             return payload
+
+        return None
 
 
 class DBlock(object):  # the depth block

--- a/pytrip/tripexecuter/execparser.py
+++ b/pytrip/tripexecuter/execparser.py
@@ -239,14 +239,13 @@ class ExecParser(object):
         Method for parsing field data
         """
         items = line.split("/")
-        _number = int(items[0].split()[1])
-        if len(items) > 1:
-            if "new" in items[1]:
-                logger.debug("Parse a new field number {:d}".format(_number))
-                field = Field()
-                field.number = _number
-                self.plan.fields.append(field)
-                self._parse_extra_args(line, self._field_args, self.plan.fields[-1])
+        number = int(items[0].split()[1])
+        if len(items) > 1 and "new" in items[1]:
+            logger.debug("Parse a new field number {:d}".format(number))
+            field = Field()
+            field.number = number
+            self.plan.fields.append(field)
+            self._parse_extra_args(line, self._field_args, self.plan.fields[-1])
 
     def _parse_scancap(self, line):
         """

--- a/pytrip/tripexecuter/execute.py
+++ b/pytrip/tripexecuter/execute.py
@@ -256,13 +256,13 @@ class Execute(object):
         if trip is None:
             logger.error("Could not find TRiP98 using path \"{:s}\"".format(self.trip_bin_path))
             raise EnvironmentError
-        else:
-            logger.info("Found {:s} version {:s}".format(trip, ver))
+
+        logger.info("Found {:s} version {:s}".format(trip, ver))
 
         # start local process running TRiP98
         self._info("\nRunning TRiP98")
         if self._norun:  # for testing, just echo the command which would be executed
-            p = Popen(["echo", self.trip_bin_path], stdout=PIPE, stderr=STDOUT, stdin=PIPE, cwd=run_dir)
+            p = Popen(["/bin/echo", self.trip_bin_path], stdout=PIPE, stderr=STDOUT, stdin=PIPE, cwd=run_dir)
         else:
             p = Popen([self.trip_bin_path], stdout=PIPE, stderr=STDOUT, stdin=PIPE, cwd=run_dir)
 
@@ -350,8 +350,8 @@ class Execute(object):
                                                                                     self.trip_bin_path))
             self._error("Could not find TRiP98 on {:s} using path \"{:s}\"".format(self.servername, self.trip_bin_path))
             raise EnvironmentError
-        else:
-            logger.info("Found {:s} version {:s} on {:s}".format(trip, ver, self.servername))
+
+        logger.info("Found {:s} version {:s} on {:s}".format(trip, ver, self.servername))
 
         # open ssh channel and run commands
         ssh = self._get_ssh_client()
@@ -610,7 +610,7 @@ class Execute(object):
         """
 
         p = Popen([self.trip_bin_path], stdout=PIPE, stderr=STDOUT, stdin=PIPE)
-        stdout, stderr = p.communicate("exit".encode('ascii'))
+        stdout, _ = p.communicate("exit".encode('ascii'))
 
         out = stdout.decode('utf-8')
 
@@ -618,8 +618,8 @@ class Execute(object):
             tripname = out.split(" ")[3][:-1]
             tripver = out.split(" ")[5].split("(")[0]
             return tripname, tripver
-        else:
-            return None, None
+
+        return None, None
 
     def test_remote_trip(self):
         """ Test if TRiP98 can be reached remotely.
@@ -632,7 +632,7 @@ class Execute(object):
 
         # test if TRiP98 can be reached
         ssh = self._get_ssh_client()
-        stdin, stdout, stderr = ssh.exec_command(tripcmd_test)
+        _, stdout, _ = ssh.exec_command(tripcmd_test)  # skipcq: BAN-B601
         out = stdout.read().decode('utf-8')
         ssh.close()
 
@@ -640,8 +640,8 @@ class Execute(object):
             tripname = out.split(" ")[3][:-1]
             tripver = out.split(" ")[5].split("(")[0]
             return tripname, tripver
-        else:
-            return None, None
+
+        return None, None
 
     def add_executor_logger(self, executor_logger):
         """ An executor_logger is of type ExecutorLogger.

--- a/pytrip/tripexecuter/field.py
+++ b/pytrip/tripexecuter/field.py
@@ -124,5 +124,5 @@ class Field(object):
             try:
                 self.isocenter = [float(_target[0]), float(_target[1]), float(_target[2])]
                 return
-            except Exception:
+            except ValueError:
                 logger.error("Expected a 'X,Y,Z' formatted string for Field().set_isocenter_from_string")

--- a/pytrip/tripexecuter/plan.py
+++ b/pytrip/tripexecuter/plan.py
@@ -254,8 +254,8 @@ class Plan(object):
         1) *.exec
         2) *.dos
         """
-        self.save_exec(images, path + ".exec")
-        self.save_data(images, path + ".exec")
+        self.save_exec(path + ".exec")
+        self.save_data(images, path)
 
     def save_exec(self, exec_path=None):
         """ Generates (overwriting) self._trip_exec, and saves it to exec_path.
@@ -283,18 +283,18 @@ class Plan(object):
         _exec = ExecParser(self)
         _exec.parse_exec(exec_path)
 
-    def save_data(self, images, path):
+    def save_data(self, _images, path):
         """ Save this plan, including associated data.
         TODO: may have to be implemented in a better way.
         """
-        t = Execute(images)
-        t.set_plan(self)
-        t.save_data(path)
+        # t = Execute(images)
+        # t.set_plan(self)
+        # t.save_data(path)
         for dos in self.dosecubes:
             dos.write(path + "." + dos.get_type() + DosCube.data_file_extension)
 
         for let in self.letcubes:
-            let.write(path + "." + dos.get_type() + DosCube.data_file_extension)
+            let.write(path + "." + let.get_type() + LETCube.data_file_extension)
 
     def load_let(self, path):
         """ Load and append a new LET cube from path to self.letcubes.
@@ -402,7 +402,7 @@ class Plan(object):
         else:
             if not self._make_sis:
                 logger.error("No SIS table loaded or generated.")
-                raise
+                raise Exception("No SIS table loaded or generated.")
             output.append(self._make_sis)
 
         # Scancap:
@@ -581,11 +581,11 @@ class Plan(object):
                 output.append('field {:d} / write file({:s}.rst) reverseorder '.format(i + 1, field.basename))
                 self.out_files.append(field.basename + ".rst")
 
-        for _field in fields:
-            if _field.save_bev_file:
-                bev_filename = _field.bev_filename
+        for i, field in enumerate(fields):
+            if field.save_bev_file:
+                bev_filename = field.bev_filename
                 if not bev_filename:
-                    bev_filename = _field.basename + ".bev.gd"
+                    bev_filename = field.basename + ".bev.gd"
                 line = "field {:d} /bev(*) file({:s})".format(i + 1, bev_filename)
                 output.append(line)
 

--- a/pytrip/util.py
+++ b/pytrip/util.py
@@ -193,8 +193,7 @@ class TRiP98FilePath(object):
         """
         if not self._is_gzipped():
             return self.name
-        else:
-            return self.name[:-3]
+        return self.name[:-3]
 
     @property
     def _filename_without_extension(self):
@@ -223,14 +222,13 @@ class TRiP98FilePath(object):
             return self._ungzipped_filename[:-len(self.header_file_extension)]
 
         # check if datafile extension present, if yes, drop it
-        elif self.data_file_extension and _ungzipped_filename.endswith(
+        if self.data_file_extension and _ungzipped_filename.endswith(
             (self.data_file_extension.lower(),
              self.data_file_extension.upper())):
             return _ungzipped_filename[:-len(self.data_file_extension)]
 
         # no extensions found, return only unzipped filename
-        else:
-            return _ungzipped_filename
+        return _ungzipped_filename
 
     @property
     def suffix(self):
@@ -280,8 +278,7 @@ class TRiP98FilePath(object):
         """
         if self._is_stem_pattern():
             return self._filename_without_extension[:-len(self.suffix)]
-        else:
-            return None
+        return None
 
     def _is_stem_pattern(self):
         """
@@ -324,10 +321,9 @@ class TRiP98FilePath(object):
         """
         if self.is_valid_header_path():
             return self._filename_without_extension + self.data_file_extension
-        elif self.is_valid_datafile_path():
+        if self.is_valid_datafile_path():
             return self.name
-        else:
-            return self.name + self.data_file_extension
+        return self.name + self.data_file_extension
 
     @property
     def header(self):
@@ -346,10 +342,9 @@ class TRiP98FilePath(object):
         """
         if self.is_valid_header_path():
             return self.name
-        elif self.is_valid_datafile_path():
+        if self.is_valid_datafile_path():
             return self._filename_without_extension + self.header_file_extension
-        else:
-            return self.name + self.header_file_extension
+        return self.name + self.header_file_extension
 
     @property
     def basename(self):
@@ -458,8 +453,7 @@ class TRiP98FileLocator(object):
                     if os.path.exists(candidate_path):
                         logger.info("Found " + candidate_path)
                         return candidate_path
-                    else:
-                        files_tried.append(candidate_path)
+                    files_tried.append(candidate_path)
         logger.warning("Checking following files: " + " , ".join(files_tried) + ". None of them exists.")
         return None
 
@@ -481,8 +475,7 @@ class TRiP98FileLocator(object):
                     candidate_path = dir_basename + suffix + datafile_extension + gzip_extension
                     if os.path.exists(candidate_path):
                         return candidate_path
-                    else:
-                        files_tried.append(candidate_path)
+                    files_tried.append(candidate_path)
         logger.warning("Checking following files: " + " , ".join(files_tried) + ". None of them exists.")
         return None
 
@@ -521,20 +514,3 @@ def get_size(start_path="."):
                 total_size += os.path.getsize(fp)
 
     return total_size
-
-
-def evaluator(funct, name='funct'):
-    """ Wrapper for evaluating a function.
-
-    :params str funct: string which will be parsed
-    :params str name: name which will be assigned to created function.
-
-    :returns: function f build from 'funct' input.
-    """
-    code = compile(funct, name, 'eval')
-
-    def f(x):
-        return eval(code, locals())
-
-    f.__name__ = name
-    return f

--- a/pytrip/utils/bevlet2oer.py
+++ b/pytrip/utils/bevlet2oer.py
@@ -91,7 +91,10 @@ class ReadGd(object):  # TODO: rename me
             out_fd.close()
 
 
-def main(args=sys.argv[1:]):
+def main(args=None):
+    if args is None:
+        args = sys.argv[1:]
+
     parser = argparse.ArgumentParser()
     parser.add_argument("gd_file", help="location of .bevlet file", type=str)
     parser.add_argument("dat_file", help="location of OER .dat to write", type=str, nargs='?')

--- a/pytrip/utils/cubeslice.py
+++ b/pytrip/utils/cubeslice.py
@@ -108,9 +108,11 @@ def load_ct_cube(filename):
     return c, c.basename
 
 
-def main(args=sys.argv[1:]):
+def main(args=None):
     """ The main function for cubeslice.py
     """
+    if args is None:
+        args = sys.argv[1:]
 
     # there are some cases when this script is run on systems without DISPLAY variable being set
     # in such case matplotlib backend has to be explicitly specified
@@ -149,26 +151,24 @@ def main(args=sys.argv[1:]):
         return 2
 
     # Check if different output path was requested. If yes, then check if it exists.
-    if parsed_args.outputdir:
-        if not os.path.isdir(parsed_args.outputdir):
-            logging.warning("Output directory " + parsed_args.outputdir + " does not exist, creating.")
-            os.makedirs(parsed_args.outputdir)
+    if parsed_args.outputdir and not os.path.isdir(parsed_args.outputdir):
+        logging.warning("Output directory " + parsed_args.outputdir + " does not exist, creating.")
+        os.makedirs(parsed_args.outputdir)
 
     data_cube, data_basename = load_data_cube(parsed_args.data)
 
     ct_cube, ct_basename = load_ct_cube(parsed_args.ct)
 
     # check cube data are compatible (if both cubes present)
-    if data_cube is not None and ct_cube is not None:
-        if not data_cube.is_compatible(ct_cube):
-            logging.error("Cubes don't match")
-            logging.info("Cube 1 " + parsed_args.data + " : ")
-            logging.info("\tshape {:d} x {:d} x {:d}".format(data_cube.dimx, data_cube.dimy, data_cube.dimz))
-            logging.info("\tpixel {:g} [cm], slice {:g} [cm]".format(data_cube.pixel_size, data_cube.slice_distance))
-            logging.info("Cube 2 " + parsed_args.ct + " : ")
-            logging.info("\tshape {:d} x {:d} x {:d}".format(ct_cube.dimx, ct_cube.dimy, ct_cube.dimz))
-            logging.info("\tpixel {:g} [cm], slice {:g} [cm]".format(ct_cube.pixel_size, ct_cube.slice_distance))
-            return 2
+    if data_cube is not None and ct_cube is not None and not data_cube.is_compatible(ct_cube):
+        logging.error("Cubes don't match")
+        logging.info("Cube 1 " + parsed_args.data + " : ")
+        logging.info("\tshape {:d} x {:d} x {:d}".format(data_cube.dimx, data_cube.dimy, data_cube.dimz))
+        logging.info("\tpixel {:g} [cm], slice {:g} [cm]".format(data_cube.pixel_size, data_cube.slice_distance))
+        logging.info("Cube 2 " + parsed_args.ct + " : ")
+        logging.info("\tshape {:d} x {:d} x {:d}".format(ct_cube.dimx, ct_cube.dimy, ct_cube.dimz))
+        logging.info("\tpixel {:g} [cm], slice {:g} [cm]".format(ct_cube.pixel_size, ct_cube.slice_distance))
+        return 2
 
     cube = None
     cube_basename = None

--- a/pytrip/utils/dicom2trip.py
+++ b/pytrip/utils/dicom2trip.py
@@ -29,9 +29,12 @@ import pytrip as pt
 logger = logging.getLogger(__name__)
 
 
-def main(args=sys.argv[1:]):
+def main(args=None):
     """ Main function for dicom2trip.py
     """
+    if args is None:
+        args = sys.argv[1:]
+
     # parse arguments
     parser = argparse.ArgumentParser()
     parser.add_argument("dicom_dir", help="location of directory with DICOM files", type=str)

--- a/pytrip/utils/dvhplot.py
+++ b/pytrip/utils/dvhplot.py
@@ -32,9 +32,11 @@ import matplotlib
 logger = logging.getLogger(__name__)
 
 
-def main(args=sys.argv[1:]):
+def main(args=None):
     """ Main function for dvhplot.py
     """
+    if args is None:
+        args = sys.argv[1:]
 
     # parse arguments
     parser = argparse.ArgumentParser()
@@ -108,10 +110,9 @@ def main(args=sys.argv[1:]):
 
     if tofile:
         logger.info("Write {}".format(tofile))
-        f = open(tofile, "w+")
-        for _x, _y in zip(vh.x, vh.y):
-            f.write("{:.3f} {:.3f}\n".format(_x, _y))
-        f.close()
+        with open(tofile, "w+") as f:
+            for _x, _y in zip(vh.x, vh.y):
+                f.write("{:.3f} {:.3f}\n".format(_x, _y))
 
     if outfile:
         plt.savefig(outfile)

--- a/pytrip/utils/gd2agr.py
+++ b/pytrip/utils/gd2agr.py
@@ -28,9 +28,12 @@ import pytrip as pt
 from pytrip.utils.gd2dat import ReadGd
 
 
-def main(args=sys.argv[1:]):
+def main(args=None):
     """ Main function for gd2agr.
     """
+    if args is None:
+        args = sys.argv[1:]
+
     parser = argparse.ArgumentParser()
     parser.add_argument("gd_file", help="location of gd file", type=str)
     parser.add_argument("dat_file", help="location of .dat to write", type=str, nargs='?')

--- a/pytrip/utils/gd2dat.py
+++ b/pytrip/utils/gd2dat.py
@@ -79,9 +79,8 @@ class ReadGd(object):
         if os.path.isfile(self.filename) is False:
             raise IOError("Could not find file " + self.filename)
 
-        gd_file = open(self.filename, 'r')
-        gd_lines = gd_file.readlines()
-        gd_file.close()
+        with open(self.filename, "r") as gd_file:
+            gd_lines = gd_file.readlines()
 
         line = gd_lines[0]
         line_len = len(line)
@@ -95,10 +94,10 @@ class ReadGd(object):
                 else:
                     break
 
-            if line[s] == 'x' or line[s] == 'X':
+            if line[s] in ('x', 'X'):
                 line_len = len(line)
                 self.xlabel = line[s + 2:line_len - 1]
-            elif line[s] == 'y' or line[s] == 'Y':
+            elif line[s] in ('y', 'Y'):
                 line_len = len(line)
                 self.ylabel = line[s + 2:line_len - 1]
             elif line[s] in ('h', 'H', 'a', 'A'):
@@ -107,24 +106,24 @@ class ReadGd(object):
                 while p < line_len:
                     l2 = line[p:p + 2]
                     legend_bool = False
-                    if l2 == 'x ' or l2 == 'X ':
+                    if l2 in ('x ', 'X '):
                         self.head.append('x')
                         self.h += 1
                         self.legend.append("x")
                         legend_bool = False
-                    elif l2 == 'y(' or l2 == 'Y(':
+                    elif l2 in ('y(', 'Y('):
                         self.head.append('y')
                         self.h += 1
                         legend_bool = True
-                    elif l2 == 'm(' or l2 == 'M(':
+                    elif l2 in ('m(', 'M('):
                         self.head.append('m')
                         self.h += 1
                         legend_bool = True
-                    elif l2 == 'n(' or l2 == 'N(':
+                    elif l2 in ('n(', 'N('):
                         self.head.append('n')
                         self.h += 1
                         legend_bool = True
-                    elif l2 == 'l(' or l2 == 'L(':
+                    elif l2 in ('l(', 'L('):
                         self.head.append('l')
                         self.h += 1
                         legend_bool = True
@@ -145,11 +144,10 @@ class ReadGd(object):
 
                                 p = t
                                 break
-                            else:
-                                t += 1
+                            t += 1
                     p += 1
 
-            elif line[s] == 'n' or line[s] == 'N':
+            elif line[s] in ('n', 'N'):
                 break
             elif line[s].isdigit() or line[s] == '-':
                 line_len = len(line)
@@ -184,104 +182,107 @@ class ReadGd(object):
                 out_file_name += "dat"
                 print('# Writing data in a ".dat" file: ' + out_file_name)
 
-        out_file = open(out_file_name, 'w')
+        with open(out_file_name, "w") as out_file:
 
-        if self.let_bool:
-            print('# Exporting also LET data  ')
+            if self.let_bool:
+                print('# Exporting also LET data  ')
 
-        if self.agr:
-            header = "# Grace project file\n# \n@version 50122 \n"
-            # header += "@page size 842, 595 \n@page scroll 5% \n"
-            header += "@page inout 5% \n@link page off \n"
+            if self.agr:
+                header = "# Grace project file\n# \n@version 50122 \n"
+                # header += "@page size 842, 595 \n@page scroll 5% \n"
+                header += "@page inout 5% \n@link page off \n"
 
-            str_out = header + '@    title  "' + self.title + ' "\n'
+                str_out = header + '@    title  "' + self.title + ' "\n'
 
-            str_out += '@    xaxis  label "' + self.xlabel
-            str_out += ' "\n@    xaxis  label char size 1.500000\n'
-            str_out += '@    xaxis  ticklabel char size 1.250000\n'
+                str_out += '@    xaxis  label "' + self.xlabel
+                str_out += ' "\n@    xaxis  label char size 1.500000\n'
+                str_out += '@    xaxis  ticklabel char size 1.250000\n'
 
-            str_out += '@    yaxis  label "' + self.ylabel
-            str_out += ' "\n@    yaxis  label char size 1.500000\n'
-            str_out += '@    yaxis  ticklabel char size 1.250000\n'
+                str_out += '@    yaxis  label "' + self.ylabel
+                str_out += ' "\n@    yaxis  label char size 1.500000\n'
+                str_out += '@    yaxis  ticklabel char size 1.250000\n'
 
-            out_file.write(str_out)
+                out_file.write(str_out)
 
-        num = -1
-        counter = 0
+            num = -1
+            counter = 0
 
-        while num < self.h - 1:
+            while num < self.h - 1:
 
-            num += 1
-            # The following feature is still under development
-            #            title = self.legend[num]
-            #            if (title == "Survival" or title == "SpecDose" \
-            #                    or title == "PhysDose" ):
-            #                print '# Skip data with the title "' + title + '"'
-            #                continue
-            #            print self.head[num]  # debug line
+                num += 1
+                # The following feature is still under development
+                #            title = self.legend[num]
+                #            if (title == "Survival" or title == "SpecDose" \
+                #                    or title == "PhysDose" ):
+                #                print '# Skip data with the title "' + title + '"'
+                #                continue
+                #            print self.head[num]  # debug line
 
-            if self.head[num] == "x":
-                continue
+                if self.head[num] == "x":
+                    continue
 
-            elif self.head[num] == 'y' or self.head[num] == 'm':  # normal data
+                if self.head[num] in ('y', 'm'):  # normal data
 
-                if self.head[num] == 'm':
-                    str_hd = self.legend[num]
-                    j = 0
-                    for sign in str_hd:
-                        if sign == '*':
-                            break
-                        j += 1
-                    _legend = str_hd[j + 1:]
+                    if self.head[num] == 'm':
+                        str_hd = self.legend[num]
+                        j = 0
+                        for sign in str_hd:
+                            if sign == '*':
+                                break
+                            j += 1
+                        _legend = str_hd[j + 1:]
+                    else:
+                        _legend = self.legend[num]
+
+                    str_out = ' \n'
+                    if not self.agr:
+                        str_out += '# '
+                    str_out += '@    s' + str(counter) + ' legend  "'
+                    str_out += _legend + '"\n'
+                    out_file.write(str_out)
+
+                    str_out = '@    s' + str(counter) + ' comment "'
+                    if not self.agr:
+                        str_out = '# ' + str_out
+                    str_out += self.filename + ' "\n'
+                    for i, ele in enumerate(self.data[num]):
+                        str_out += self.xdata[i] + ' ' + str(ele) + '\n'
+                    out_file.write(str_out)
+                    counter += 1
+
                 else:
+                    continue
+
+                # special handling for 'm'
+                #
+                # A column with the header 'm' should be multiplied with the
+                # column to the left of it (cf GD manual).
+                #
+                if self.head[num] == 'm':
+
+                    str_out = ' \n'
+                    if not self.agr:
+                        str_out += '# '
                     _legend = self.legend[num]
+                    str_out += '@    s' + str(counter) + ' legend  "'
+                    str_out += _legend + '"\n'
+                    if not self.agr:
+                        str_out += '# '
+                    str_out += '@    s' + str(counter)
+                    str_out += ' comment "' + self.filename + ' "\n'
+                    for i, ele in enumerate(self.indata):
+                        str_out += self.xdata[i] + ' ' + str((float(ele[num]) * float(ele[num - 1]))) + '\n'
+                    out_file.write(str_out)
 
-                str_out = ' \n'
-                if not self.agr:
-                    str_out += '# '
-                str_out += '@    s' + str(counter) + ' legend  "'
-                str_out += _legend + '"\n'
-                out_file.write(str_out)
-
-                str_out = '@    s' + str(counter) + ' comment "'
-                if not self.agr:
-                    str_out = '# ' + str_out
-                str_out += self.filename + ' "\n'
-                for i, ele in enumerate(self.data[num]):
-                    str_out += self.xdata[i] + ' ' + str(ele) + '\n'
-                out_file.write(str_out)
-                counter += 1
-
-            else:
-                continue
-
-            # special handling for 'm'
-            #
-            # A column with the header 'm' should be multiplied with the
-            # column to the left of it (cf GD manual).
-            #
-            if self.head[num] == 'm':
-
-                str_out = ' \n'
-                if not self.agr:
-                    str_out += '# '
-                _legend = self.legend[num]
-                str_out += '@    s' + str(counter) + ' legend  "'
-                str_out += _legend + '"\n'
-                if not self.agr:
-                    str_out += '# '
-                str_out += '@    s' + str(counter)
-                str_out += ' comment "' + self.filename + ' "\n'
-                for i, ele in enumerate(self.indata):
-                    str_out += self.xdata[i] + ' ' + str((float(ele[num]) * float(ele[num - 1]))) + '\n'
-                out_file.write(str_out)
-
-                counter += 1
+                    counter += 1
 
 # end special handling for 'm'
 
 
-def main(args=sys.argv[1:]):
+def main(args=None):
+    if args is None:
+        args = sys.argv[1:]
+
     parser = argparse.ArgumentParser()
     parser.add_argument("gd_file", help="location of gd file", type=str)
     parser.add_argument("dat_file", help="location of .dat to write", type=str, nargs='?')

--- a/pytrip/utils/rst2sobp.py
+++ b/pytrip/utils/rst2sobp.py
@@ -27,9 +27,12 @@ import argparse
 import pytrip as pt
 
 
-def main(args=sys.argv[1:]):
+def main(args=None):
     """ Main function of the rst2sobp script.
     """
+    if args is None:
+        args = sys.argv[1:]
+
     parser = argparse.ArgumentParser()
     parser.add_argument("rst_file", help="path to .rst input file in TRiP98 format", type=str)
     parser.add_argument("sobp_file", help="path to the SHIELD-HIT12A/FLUKA sobp.dat output file", type=str)

--- a/pytrip/utils/rst_plot.py
+++ b/pytrip/utils/rst_plot.py
@@ -27,13 +27,16 @@ import logging
 import pytrip as pt
 
 
-def main(args=sys.argv[1:]):
+def main(args=None):
     # there are some cases when this script is run on systems without DISPLAY variable being set
     # in such case matplotlib backend has to be explicitly specified
     # we do it here and not in the top of the file, as inteleaving imports with code lines is discouraged
     import matplotlib
     matplotlib.use('Agg')
     from pylab import plt, ylabel, grid, xlabel, array
+
+    if args is None:
+        args = sys.argv[1:]
 
     parser = argparse.ArgumentParser()
     parser.add_argument("rst_file", help="location of rst file in TRiP98 format", type=str)

--- a/pytrip/utils/trip2dicom.py
+++ b/pytrip/utils/trip2dicom.py
@@ -26,13 +26,17 @@ import logging
 import argparse
 
 import pytrip as pt
+from pytrip.error import FileNotFound
 
 logger = logging.getLogger(__name__)
 
 
-def main(args=sys.argv[1:]):
+def main(args=None):
     """ Main function for trip2dicom.py
     """
+    if args is None:
+        args = sys.argv[1:]
+
     # parse arguments
     parser = argparse.ArgumentParser()
     parser.add_argument("ctx_data", help="location of CT file (header or data) in TRiP98 format", type=str)
@@ -54,7 +58,10 @@ def main(args=sys.argv[1:]):
     c = pt.CtxCube()
     try:
         c.read(parsed_args.ctx_data)
-    except Exception as e:
+    except FileNotFound as e:
+        logger.error(e)
+        return 1
+    except ValueError as e:
         logger.error(e)
         return 1
 

--- a/pytrip/vdx.py
+++ b/pytrip/vdx.py
@@ -296,11 +296,9 @@ class VdxCube:
         :param content: the vdx file contents as an array of strings.
         :returns: vdx version string, e.g. "1.2" or "2.0"
         """
-        for line in content:
-            if line.strip().startswith("vdx_file_version"):
-                return line.split()[1]
-            else:
-                return "1.2"
+        if content[0].strip().startswith("vdx_file_version"):
+            return content[0].split()[1]
+        return "1.2"
 
     def read_vdx(self, path):
         """ Reads a structure file in Voxelplan format.
@@ -309,9 +307,8 @@ class VdxCube:
         """
         self.basename = os.path.basename(path).split(".")[0]
         self.path = path
-        fp = open(path, "r")
-        content = fp.read().split('\n')
-        fp.close()
+        with open(path, "r") as fp:
+            content = fp.read().split('\n')
 
         self.version = self.vdx_version(content)
 
@@ -324,17 +321,15 @@ class VdxCube:
             if not header_full:
                 if line.startswith("all_indices_zero_based"):
                     self.zero_based = True
-
-            #                TODO number_of_vois not used
-            #                elif "number_of_vois" in line:
-            #                    number_of_vois = int(line.split()[1])
+               # TODO number_of_vois not used
+               # elif "number_of_vois" in line:
+               #     number_of_vois = int(line.split()[1])
             if line.startswith("voi"):
                 v = Voi(line.split()[1], self.cube)
                 if self.version == "1.2":
-                    _token = line.split()
-                    if len(_token) == 6:
-                        if _token[5] != '0':
-                            i = v.read_vdx_old(content, i)
+                    token = line.split()
+                    if len(token) == 6 and token[5] != '0':
+                        i = v.read_vdx_old(content, i)
                 else:
                     i = v.read_vdx(content, i)
                 self.add_voi(v)
@@ -537,8 +532,7 @@ def _voi_point_cmp(a, b):
         c = a[1] - b[1]
     if c < 0:
         return -1
-    else:
-        return 1
+    return 1
 
 
 def create_cube(cube, name, center, width, height, depth):


### PR DESCRIPTION
fixes:
- Consider using in - PYL-R1714
- Unnecessary parentheses after keyword - PYL-C0325
- Inconsistent return statements - PYL-R1710
- Audit: Starting a process with a partial executable path - BAN-B607
- Possible shell injection via Paramiko call - BAN-B601
- Audit required: Use of eval - PYL-W0123
- Too many positional arguments in function call - PYL-E1121
- Missing argument in function call - PYL-E1120
- Unnecessary else / elif used after break - PYL-R1723
- Unnecessary elif / else block after continue - PYL-R1724
- Unnecessary else / elif used after return - PYL-R1705
- Unnecessary else/elif used after raise - PYL-R1720
- Loop variable used outside the loop - PYL-W0631
- Exception caught is very general - PYL-W0703
- Comparison with itself - PYL-R0124
- Argument redefined from local - PYL-R1704
- Re-definition found for builtin function - PYL-W0622
- Implicit enumerate calls found - PTC-W0060
- if statements can be merged - PTC-W0048
- Function/method with an empty body - PTC-W0049
- File opened without the with statement - PTC-W0010
- Unused variable found - PYL-W0612
- Dangerous default argument - PYL-W0102