### PR TITLE
reduce remote results size

### DIFF
--- a/pytrip/tripexecuter/execute.py
+++ b/pytrip/tripexecuter/execute.py
@@ -335,6 +335,8 @@ class Execute(object):
             norun + tripcmd,
 
             # compress to tarball
+            "cd " + quote(remote_run_dir) + ";" +
+            "rm " + plan.basename + ".hed " + plan.basename + ".ctx " + plan.basename + ".vdx;" +
             "cd " + quote(self.remote_base_dir) + ";" +
             "echo Size to compress: $(du -sh " + quote(remote_rel_run_dir) + " | cut -f1)iB;" +
             "tar -zc " + tar_log_parameters + " --checkpoint-action=echo=\"Compressed bytes %{}T\" " +


### PR DESCRIPTION
remote execution was sending back all files including input files (e.g. ctx, which is big)