### PR TITLE
Python 3.6 was removed from ubuntu:22.04

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,12 +45,14 @@ jobs:
     needs: [initialise]
     strategy:
        matrix:
-         python-version: ['2.7', '3.10', '3.11']
+         python-version: ['3.10', '3.11']
          platform: [ubuntu-latest, windows-latest]
-         exclude:
-           # skip this config, because it is slow
+         include:
            - python-version: '2.7'
-             platform: windows-latest
+             platform: ubuntu-latest
+           - python-version: '3.6'
+             platform: ubuntu-20.04
+
     steps:
       - uses: actions/checkout@v3
 
@@ -94,6 +96,9 @@ jobs:
       matrix:
         python-version: ['2.7', '3.7', '3.8', '3.9', '3.10', '3.11']
         platform: [ubuntu-latest, windows-latest]
+        include:
+           - python-version: '3.6'
+             platform: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python
@@ -145,7 +150,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4.3.0
         with:
-          python-version: '3.9'
+          python-version: '3.10'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,7 @@ jobs:
     needs: [initialise]
     strategy:
        matrix:
-         python-version: ['2.7', '3.6', '3.10', '3.11']
+         python-version: ['2.7', '3.10', '3.11']
          platform: [ubuntu-latest, windows-latest]
          exclude:
            # skip this config, because it is slow
@@ -92,7 +92,7 @@ jobs:
     needs: [initialise, smoke_test]
     strategy:
       matrix:
-        python-version: ['2.7', '3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['2.7', '3.7', '3.8', '3.9', '3.10', '3.11']
         platform: [ubuntu-latest, windows-latest]
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
            - python-version: '2.7'
              platform: ubuntu-latest
            - python-version: '3.6'
-             platform: ubuntu-20.04
+             platform: ubuntu-20.04 # 3.6 is not available on Ubuntu 22.04 (currently latest)
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
closes #706 