### PR TITLE
Drop support for python 2.x

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,8 +48,6 @@ jobs:
          python-version: ['3.10', '3.11']
          platform: [ubuntu-latest, windows-latest]
          include:
-           - python-version: '2.7'
-             platform: ubuntu-latest
            - python-version: '3.6'
              platform: ubuntu-20.04 # 3.6 is not available on Ubuntu 22.04 (currently latest)
 
@@ -94,7 +92,7 @@ jobs:
     needs: [initialise, smoke_test]
     strategy:
       matrix:
-        python-version: ['2.7', '3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
         platform: [ubuntu-latest, windows-latest]
         include:
            - python-version: '3.6'
@@ -105,14 +103,6 @@ jobs:
       uses: actions/setup-python@v4.6.1
       with:
         python-version: ${{ matrix.python-version }}
-
-    - name: Install Visual C++ 9.0 for Python 2.7
-      # we download from web.archive.org, because it is not accessible on official microsoft site
-      # https://stackoverflow.com/questions/43645519/microsoft-visual-c-9-0-is-required
-      if: matrix.platform == 'windows-latest' && matrix.python-version == '2.7'
-      run: |
-        C:\msys64\usr\bin\wget.exe --progress=dot:mega --tries=50 'https://web.archive.org/web/20200709160228if_/https://download.microsoft.com/download/7/9/6/796EF2E4-801B-4FC4-AB28-B59FBF6D907B/VCForPython27.msi'
-        msiexec /i VCForPython27.msi /qn
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -174,7 +174,7 @@ jobs:
     needs: [initialise, full_tests]
     strategy:
        matrix:
-         python-versions: ["cp27-cp27m", "cp36-cp36m", "cp37-cp37m","cp38-cp38", "cp39-cp39"]
+         python-versions: ["cp36-cp36m", "cp37-cp37m","cp38-cp38", "cp39-cp39"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -283,58 +283,11 @@ jobs:
         path: ./dist/pytrip98*manylinux2014_x86_64.whl
         if-no-files-found: error
 
-  build_wheels_macOS:
-    # this job is triggered only in following cases:
-    #  - if commit message contains specific keyword: [build]
-    #  - if commit message starts with specific keyword: dependabot_ (for PRs created with dependabot)
-    #  - on master branch
-    #  - on release tags (named v*)
-    if: >
-      contains(needs.initialise.outputs.commit_message, '[build]') ||
-      startsWith(needs.initialise.outputs.commit_message, 'dependabot_') ||
-      github.ref == 'refs/heads/master' ||
-      (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v'))
-    name: Wheels on macOS
-    needs: [initialise, full_tests]
-    runs-on: macos-10.15
-
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - uses: actions/setup-python@v4.6.1
-        with:
-          python-version: "3.9"
-
-      - name: install dependencies
-        run: |
-          pip install --upgrade setuptools pip wheel
-          pip install cibuildwheel
-
-      - name: show environment
-        run: |
-          pip freeze
-
-      - name: list target wheels
-        run: |
-          python -m cibuildwheel . --print-build-identifiers
-
-      - name: build wheels
-        run: python -m cibuildwheel --output-dir wheelhouse
-        env:
-          CIBW_BUILD_VERBOSITY: "1"
-          CIBW_BUILD: "cp36-* cp37-* cp38-* cp39-*"  # add MacOS 3.10 support
-
-      - uses: actions/upload-artifact@v3
-        with:
-          path: ./wheelhouse/*.whl
-          if-no-files-found: error
    
   upload_wheels:
     # upload wheels only when git tag and release is created
     name: Upload wheels
-    needs: [initialise, build_sdist, build_wheels_manylinux1, build_wheels_manylinux2010, build_wheels_manylinux2014, build_wheels_macOS]
+    needs: [initialise, build_sdist, build_wheels_manylinux1, build_wheels_manylinux2010, build_wheels_manylinux2014]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v3

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,9 +10,6 @@ environment:
   PYPIUSER: __token__
   matrix:
     - platform: x64
-      PYTHON: "C:\\Python27-x64"
-
-    - platform: x64
       PYTHON: "C:\\Python36-x64"
 
     - platform: x64

--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -6,7 +6,7 @@ Development
 -----------
 
 * Niels Bassler - Stockholm University, Sweden
-* Leszek Grzanka - IFJ-PAN, Poland <leszek.grzanka@gmail.com>
+* Leszek Grzanka - IFJ-PAN, Poland <leszek.grzanka@ifj.edu.pl>
 * Jakob Toftegaard - Aarhus University Hospital, Denmark
 
 Contributors

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -133,7 +133,7 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 3.5-3.11. Check
+3. The pull request should work for Python 3.6-3.11. Check
    https://github.com/pytrip/pytrip/actions
    and make sure that the tests pass for all supported Python versions.
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -133,7 +133,7 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 2.7, 3.5-3.10. Check
+3. The pull request should work for Python 3.5-3.11. Check
    https://github.com/pytrip/pytrip/actions
    and make sure that the tests pass for all supported Python versions.
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -50,10 +50,10 @@ command, or read the detailed documentation.
 Quick Installation Guide
 ========================
 
-PyTRiP is available for python 3.5 or later, and can be installed via pip. 
+PyTRiP is available for python 3.6 or later, and can be installed via pip. 
 
-We recommend that you run a modern Linux distribution, like: **Ubuntu 16.04** or newer, **Debian 9 Stretch**
-(currently known as testing) or any updated rolling release (archLinux, openSUSE tumbleweed). In that case,
+We recommend that you run a modern Linux distribution, like: **Ubuntu 22.04** or newer, **Debian 11**
+ or any updated rolling release (archLinux, openSUSE tumbleweed). In that case,
 be sure you have **python** and **python-pip** installed.
 To get them on Debian or Ubuntu, type being logged in as normal user::
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -50,8 +50,7 @@ command, or read the detailed documentation.
 Quick Installation Guide
 ========================
 
-PyTRiP is available for python 2.7, 3.5 or later, and can be installed via pip. If you intend to use **pytripgui** you
-need the python 2.7 version.
+PyTRiP is available for python 3.5 or later, and can be installed via pip. 
 
 We recommend that you run a modern Linux distribution, like: **Ubuntu 16.04** or newer, **Debian 9 Stretch**
 (currently known as testing) or any updated rolling release (archLinux, openSUSE tumbleweed). In that case,

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -19,7 +19,7 @@ Try if one of following commands (printing Python version) works::
 At the time of writing Python language interpreter has two popular versions: 2.x (Python 2) and 3.x (Python 3) families.
 Command ``python`` invokes either Python 2 or 3, while ``python3`` can invoke only Python 3.
 
-**pytrip** supports most of the modern Python versions, mainly: 3.5 - 3.11.
+**pytrip** supports most of the modern Python versions, mainly: 3.6 - 3.11.
 Check if your interpreter version is supported.
 
 If none of ``python`` and ``python3`` commands are present, then Python interpreter has to be installed.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -19,7 +19,7 @@ Try if one of following commands (printing Python version) works::
 At the time of writing Python language interpreter has two popular versions: 2.x (Python 2) and 3.x (Python 3) families.
 Command ``python`` invokes either Python 2 or 3, while ``python3`` can invoke only Python 3.
 
-**pytrip** supports most of the modern Python versions, mainly: 2.7, 3.5 - 3.10.
+**pytrip** supports most of the modern Python versions, mainly: 3.5 - 3.11.
 Check if your interpreter version is supported.
 
 If none of ``python`` and ``python3`` commands are present, then Python interpreter has to be installed.
@@ -44,7 +44,7 @@ Installing using pip (all platforms)
 The easiest way to install PyTRiP98 is using `pip <https://pypi.python.org/pypi/pip>`_::
 
 .. note::
-    Pip comes pre-installed with Python newer than 3.4 and 2.7 (for 2.x family)
+    Pip comes pre-installed with Python newer than 3.4
 
 
 Administrator installation (root access)

--- a/pytrip/utils/cubeslice.py
+++ b/pytrip/utils/cubeslice.py
@@ -108,7 +108,7 @@ def load_ct_cube(filename):
     return c, c.basename
 
 
-def main(args=None):
+def main(args=None):  # skipcq: PY-R1000
     """ The main function for cubeslice.py
     """
     if args is None:

--- a/pytrip/utils/cubeslice.py
+++ b/pytrip/utils/cubeslice.py
@@ -251,7 +251,7 @@ def main(args=None):
     # loop over each slice
     for slice_id in range(slice_start, slice_stop + 1):
 
-        output_filename = "{:s}_{:03d}.png".format(cube_basename, slice_id)
+        output_filename = f"{cube_basename}_{slice_id:03d}.png"
 
         slice_str = str(slice_id) + "/" + str(cube.dimz)
         if parsed_args.outputdir is not None:
@@ -262,9 +262,7 @@ def main(args=None):
         elif parsed_args.verbosity > 0:
             logging.info("Write slice number: " + slice_str + " to " + output_filename)
 
-        slice_str = "Slice #: {:3d}/{:3d}\nSlice position: {:6.2f} mm".format(slice_id,
-                                                                              cube.dimz,
-                                                                              cube.slice_to_z(slice_id))
+        slice_str = f"Slice #: {slice_id:3d}/{cube.dimz:3d}\nSlice position: {cube.slice_to_z(slice_id):6.2f} mm"
         text_slice.set_text(slice_str)
 
         if ct_cube is not None:

--- a/pytrip/utils/cubeslice.py
+++ b/pytrip/utils/cubeslice.py
@@ -24,7 +24,7 @@ import logging
 import os
 import sys
 
-from numpy import arange, ma, NINF
+import numpy as np
 
 import pytrip as pt
 from pytrip.util import TRiP98FilePath
@@ -222,7 +222,10 @@ def main(args=None):
     data_colorscale_max = parsed_args.csmax
     if data_colorscale_max is None and data_cube is not None:
         data_colorscale_max = cube.cube.max()
-    data_cube.cube.clip(NINF, data_colorscale_max, data_cube.cube)
+    smallest_number = np.NINF
+    if np.issubdtype(data_cube.cube.dtype, np.integer):
+        smallest_number = np.iinfo(data_cube.cube.dtype).min
+    data_cube.cube.clip(smallest_number, data_colorscale_max, data_cube.cube)
 
     # Prepare figure and subplot (axis), they will stay the same during the loop
     fig = plt.figure()
@@ -285,7 +288,7 @@ def main(args=None):
 
             # optionally add HU bar
             if parsed_args.HUbar and ct_cb is None:
-                ct_cb = fig.colorbar(ct_im, ax=ax, ticks=arange(-1000, 3000, 200), orientation='horizontal')
+                ct_cb = fig.colorbar(ct_im, ax=ax, ticks=np.arange(-1000, 3000, 200), orientation='horizontal')
                 ct_cb.set_label('HU')
 
         if data_cube is not None:
@@ -303,7 +306,7 @@ def main(args=None):
             dmax = data_cube.cube.max() * 1.1
             if data_colorscale_max is not None and data_cube is not None:
                 dmax = data_colorscale_max * 1.1
-            tmpdat = ma.masked_where(data_slice <= dmin, data_slice)  # Sacrificial goat
+            tmpdat = np.ma.masked_where(data_slice <= dmin, data_slice)  # Sacrificial goat
 
             # plot new data cube
             data_im = ax.imshow(

--- a/pytrip/utils/cubeslice.py
+++ b/pytrip/utils/cubeslice.py
@@ -96,7 +96,7 @@ def load_ct_cube(filename):
         logging.warning("Empty CT cube filename")
         return None, None
 
-    logging.info("Reading " + filename)
+    logging.info("Reading", filename)
     c = pt.CtxCube()
     c.read(filename)
     logging.info("CT cube shape" + str(c.cube.shape))

--- a/pytrip/utils/cubeslice.py
+++ b/pytrip/utils/cubeslice.py
@@ -96,7 +96,7 @@ def load_ct_cube(filename):
         logging.warning("Empty CT cube filename")
         return None, None
 
-    logging.info("Reading", filename)
+    logging.info("Reading %s", filename)
     c = pt.CtxCube()
     c.read(filename)
     logging.info("CT cube shape" + str(c.cube.shape))

--- a/setup.py
+++ b/setup.py
@@ -220,7 +220,6 @@ setuptools.setup(
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
         'Programming Language :: C',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',

--- a/setup.py
+++ b/setup.py
@@ -247,4 +247,4 @@ setuptools.setup(
             'spc2pdf=pytrip.utils.spc2pdf:main',
         ],
     },
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.3.*, !=3.5.*')
+    python_requires='>=3.6')

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #
-#    Copyright (C) 2010-2022 PyTRiP98 Developers.
+#    Copyright (C) 2010-2023 PyTRiP98 Developers.
 #
 #    This file is part of PyTRiP98.
 #
@@ -140,31 +140,22 @@ extensions = [
 # |      1.14     | 12 (0xc)  | 2.7,  3.4 - 3.6 | linux, mac, win |
 # |      1.13     | 11 (0xb)  | 2.7,  3.4 - 3.6 | linux, mac, win |
 # |      1.12     | 10 (0xa)  | 2.7,  3.4 - 3.6 | linux, mac, win |
-# |      1.11     | 10 (0xa)  | 2.7,  3.4 - 3.5 | linux, mac, win |
-# |      1.10     | 10 (0xa)  | 2.7,  3.3 - 3.5 |      linux      |
-# |       1.9     |  9 (0x9)  | 2.7,  3.3 - 3.5 |      linux      |
 # ----------------------------------------------------------------|
 
 
 # as for now pydicom is broken under python 3.11, once this is fixed we need to replace it with normal version
 install_requires = [
-    "matplotlib; python_version > '3.5'",
-    "matplotlib<3.1 ; python_version <= '3.5'",
+    "matplotlib",
     "pydicom>=2.3.1 ; python_version == '3.11'",
     "pydicom ; python_version < '3.11'",
-    "scipy ; python_version > '3.5'",
-    "scipy<1.3 ; python_version <= '3.5'",
-    "kiwisolver==1.1 ; python_version <= '3.5'",
-    "cffi<1.15 ; python_version <= '3.5'",
-    "enum34 ; python_version < '3.5'",  # python 3.4 and 2.7
+    "scipy",
     # full range of NumPy version with support for given python version
     "numpy>=1.23.3 ; python_version == '3.11'",
     "numpy>=1.21.4 ; python_version == '3.10'",
     "numpy>=1.20 ; python_version == '3.9'",
     "numpy>=1.18 ; python_version == '3.8'",
     "numpy>=1.15 ; python_version == '3.7'",
-    "numpy>=1.12,<1.20 ; python_version == '3.6'",
-    "numpy>=1.11,<1.15 ; python_version < '3.5'"  # python 3.4 and 2.7
+    "numpy>=1.12,<1.20 ; python_version == '3.6'"
 ]
 
 # oldest NumPy version with support for given python version
@@ -174,8 +165,7 @@ setup_requires = [
     "numpy==1.20.0 ; python_version == '3.9'",
     "numpy==1.18.0 ; python_version == '3.8'",
     "numpy==1.15.0 ; python_version == '3.7'",
-    "numpy==1.12.0 ; python_version == '3.6'",
-    "numpy==1.11.0 ; python_version < '3.6'"  # python 3.5, 3.4 and 2.7
+    "numpy==1.12.0 ; python_version == '3.6'"
 ]
 
 extras_require = {


### PR DESCRIPTION
Python2 was deprecated in 2020. In 2023 it was removed from GitHub actions python settings.
The idea is to support python from 3.6 (released in 2016) onwards