### PR TITLE
Docs update

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,6 +26,11 @@ Installation
 PyTRiP98 is distributed as pre-built wheels for CPython 3.9–3.13 on Linux, macOS and Windows. The wheels are
 produced by `cibuildwheel <https://cibuildwheel.pypa.io/>`_ via GitHub Actions. NumPy 2.x is required.
 
+We strongly recommend using a Python virtual environment::
+
+    python -m venv venv
+    source venv/bin/activate  # On Windows: venv\Scripts\activate
+
 Basic installation (latest release from PyPI)::
 
 	pip install pytrip98
@@ -36,9 +41,11 @@ Optional remote execution support (adds ``paramiko``)::
 
 To build from source (requires a C compiler and Python headers)::
 
-	git clone https://github.com/pytrip/pytrip.git
-	cd pytrip
-	pip install .
+    git clone --recurse-submodules https://github.com/pytrip/pytrip.git
+    cd pytrip
+    python -m venv venv
+    source venv/bin/activate  # On Windows: venv\Scripts\activate
+    pip install -e .
 
 The build is managed by ``pyproject.toml`` (PEP 621) and uses ``setuptools``; NumPy (>=2.0) headers are installed
 during wheel builds to ensure a stable ABI.
@@ -48,10 +55,12 @@ Local Development
 
 To set up a local development environment:
 
-1. Clone the repository::
+1. Clone the repository (with test-data submodules)::
 
-    git clone https://github.com/pytrip/pytrip.git
+    git clone --recurse-submodules https://github.com/pytrip/pytrip.git
     cd pytrip
+    # If you already cloned without submodules:
+    #   git submodule update --init --recursive
 
 2. Create and activate a virtual environment::
 
@@ -60,12 +69,13 @@ To set up a local development environment:
 
 3. Install dependencies and the package in editable mode::
 
-    pip install -r tests/requirements-test.txt
-    pip install -e .
+    pip install -e .[test]
+    # If your pip complains about NumPy headers, install NumPy first:
+    #   pip install numpy
 
 4. Run tests::
 
-    pytest tests/
+    python -m pytest tests/
 
 5. Build the package locally::
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -2,13 +2,15 @@
 
 Detailed Installation Guide
 ===========================
-This guide covers prerequisites, wheel installation from PyPI and building from source using ``pyproject.toml``.
+This guide covers prerequisites, virtual environments, wheel installation from PyPI, and building from source using ``pyproject.toml``.
 
 
 Prerequisites
 -------------
 
-**PyTRiP** works under Linux and Mac OSX operating systems.
+**PyTRiP** works under Linux, macOS, and Windows.
+
+For contributors and developers, we strongly recommend working on Linux or macOS for the smoothest build and tooling experience.
 
 First we need to check if Python interpreter is installed.
 Try if one of following commands (printing Python version) works::
@@ -26,7 +28,7 @@ We suggest to use the newest version available (from 3.x family).
 Python installers can be found at the python web site
 (http://python.org/download/).
 
-PyTRiP relies on these core packages which are installed automatically when using pip:
+PyTRiP relies on these core packages which are installed automatically when using pip or editable installs:
 
     * `NumPy <http://www.numpy.org/>`_ – Array and numerical operations (ABI handled during wheel builds).
     * `SciPy <https://scipy.org/>`_ – Scientific routines.
@@ -39,59 +41,52 @@ Optional remote execution support via SSH requires:
     * `paramiko <http://www.paramiko.org/>`_ – Install with ``pip install pytrip98[remote]``.
 
 Installing from PyPI (All Platforms)
------------------------------------
+------------------------------------
 
 The easiest way to install PyTRiP98 is using `pip <https://pypi.python.org/pypi/pip>`_ wheels. Pre-built wheels
 are generated for Linux, macOS and Windows using `cibuildwheel <https://cibuildwheel.pypa.io/>`_ and include the
 compiled C extensions.
 
-Basic installation::
+We strongly recommend using a virtual environment:
+
+Create and activate a virtual environment::
+
+    python -m venv venv
+    source venv/bin/activate  # On Windows: venv\Scripts\activate
+
+Install the latest release from PyPI::
 
     pip install pytrip98
 
 With remote execution extras::
 
-    pip install pytrip98[remote]
+    pip install "pytrip98[remote]"
 
-
-Administrator (system-wide) install::
-
-    sudo pip install pytrip98
-
-Upgrade system-wide installation::
-
-    sudo pip install --upgrade pytrip98
-
-Uninstall::
-
-    sudo pip uninstall pytrip98
-
-
-User (local) install::
-
-    pip install pytrip98 --user
-
-Upgrade local installation::
-
-    pip install --upgrade pytrip98 --user
-
-Uninstall::
-
-    pip uninstall pytrip98
-
-Executables (e.g. ``cubeslice``) will be placed in ``$HOME/.local/bin``; ensure this directory is on your ``PATH``.
+Executables (e.g. ``cubeslice``) will be placed in your virtual environment's ``bin`` (Linux/macOS) or ``Scripts`` (Windows) directory.
 
 Building From Source
 --------------------
 
 If you need to build from source (e.g. for development or unsupported architectures)::
 
-    git clone https://github.com/pytrip/pytrip.git
+    git clone --recurse-submodules https://github.com/pytrip/pytrip.git
     cd pytrip
     python -m venv venv
     source venv/bin/activate  # On Windows: venv\Scripts\activate
-    pip install -e .
+    # Editable install with test tools (pytest/flake8)
+    pip install -e .[test]
+    # If your pip complains about NumPy headers, install NumPy first:
+    #   pip install numpy
 
-During wheel builds a minimal NumPy version appropriate for your Python interpreter is pre-installed to ensure
+Run the test suite to verify your setup::
+
+    python -m pytest tests/
+
+Optionally build distribution artifacts (wheel and sdist)::
+
+    pip install build
+    python -m build
+
+During official wheel builds a minimal NumPy version appropriate for your Python interpreter is pre-installed to ensure
 stable binary compatibility of the C extensions.
 


### PR DESCRIPTION
This pull request updates the installation and development instructions for PyTRiP98 to emphasize the use of Python virtual environments, clarify platform support, and streamline the process for both users and contributors. The documentation now provides more robust guidance for installing from PyPI and building from source, with improved instructions for editable installs, test dependencies, and submodule usage.

**Installation and environment setup improvements:**

* Strongly recommend and provide instructions for creating and activating a Python virtual environment before installing PyTRiP98, both in `README.rst` and `docs/install.rst`. [[1]](diffhunk://#diff-7b3ed02bc73dc06b7db906cf97aa91dec2b2eb21f2d92bc5caa761df5bbc168fR29-R33) [[2]](diffhunk://#diff-379774f5c6e537f2001c951863c6ac577b56eb5c6e61cc581dce95143760ff36L5-R13) [[3]](diffhunk://#diff-379774f5c6e537f2001c951863c6ac577b56eb5c6e61cc581dce95143760ff36L42-R90)
* Updated platform support language to explicitly include Linux, macOS, and Windows, and recommend Linux/macOS for contributors and developers for smoother tooling.

**Source build and development workflow enhancements:**

* Updated instructions to always clone the repository with submodules using `git clone --recurse-submodules`, and added guidance for updating submodules if previously omitted. [[1]](diffhunk://#diff-7b3ed02bc73dc06b7db906cf97aa91dec2b2eb21f2d92bc5caa761df5bbc168fL39-R48) [[2]](diffhunk://#diff-7b3ed02bc73dc06b7db906cf97aa91dec2b2eb21f2d92bc5caa761df5bbc168fL51-R63)
* Changed editable install instructions to use `pip install -e .[test]` for local development, ensuring test dependencies are installed, and added troubleshooting for NumPy header issues. [[1]](diffhunk://#diff-7b3ed02bc73dc06b7db906cf97aa91dec2b2eb21f2d92bc5caa761df5bbc168fL63-R78) [[2]](diffhunk://#diff-379774f5c6e537f2001c951863c6ac577b56eb5c6e61cc581dce95143760ff36L42-R90)
* Added steps for running the test suite with `python -m pytest tests/` and building distribution artifacts with `python -m build` in the source build instructions. [[1]](diffhunk://#diff-7b3ed02bc73dc06b7db906cf97aa91dec2b2eb21f2d92bc5caa761df5bbc168fL63-R78) [[2]](diffhunk://#diff-379774f5c6e537f2001c951863c6ac577b56eb5c6e61cc581dce95143760ff36L42-R90)

**Documentation clarity and consistency:**

* Clarified that core dependencies are installed automatically via pip or editable installs, and improved the explanation of where executables are placed depending on environment and platform. [[1]](diffhunk://#diff-379774f5c6e537f2001c951863c6ac577b56eb5c6e61cc581dce95143760ff36L29-R31) [[2]](diffhunk://#diff-379774f5c6e537f2001c951863c6ac577b56eb5c6e61cc581dce95143760ff36L42-R90)