### PR TITLE
Add support for Python 3.14 in workflows and documentation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.13']
+        python-version: ['3.13', '3.14']
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -55,7 +55,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        cibw_python: ["cp39", "cp310", "cp311", "cp312", "cp313"]
+        cibw_python: ["cp39", "cp310", "cp311", "cp312", "cp313", "cp314"]
 
     steps:
     - uses: actions/checkout@v6
@@ -66,7 +66,7 @@ jobs:
     - uses: pypa/cibuildwheel@v3.3.0
       env:
         CIBW_BUILD: ${{ matrix.cibw_python }}-*
-        # Build exactly one Python ABI per worker using a matrix (3 OSes × 5 Python versions).
+        # Build exactly one Python ABI per worker using a matrix (3 OSes × 6 Python versions).
         # Packaging itself is quick (~30s) but tests are lengthy; parallel workers keep total time manageable.
 
     - name: Verify clean directory

--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ how to use the PyTRiP library.
 Installation
 ------------
 
-PyTRiP98 is distributed as pre-built wheels for CPython 3.9–3.13 on Linux, macOS and Windows. The wheels are
+PyTRiP98 is distributed as pre-built wheels for CPython 3.9–3.14 on Linux, macOS and Windows. The wheels are
 produced by `cibuildwheel <https://cibuildwheel.pypa.io/>`_ via GitHub Actions. NumPy 2.x is required.
 
 Basic installation (latest release from PyPI)::

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -132,7 +132,7 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 3.9-3.13. Check
+3. The pull request should work for Python 3.9-3.14. Check
    https://github.com/pytrip/pytrip/actions
    and make sure that the tests pass for all supported Python versions.
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -16,7 +16,7 @@ Try if one of following commands (printing Python version) works::
     $ python --version
     $ python3 --version
 
-**pytrip** supports modern Python versions 3.9 – 3.13. Ensure your interpreter is within this range.
+**pytrip** supports modern Python versions 3.9 – 3.14. Ensure your interpreter is within this range.
 
 If none of ``python`` and ``python3`` commands are present, then Python interpreter has to be installed.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Programming Language :: Python :: Implementation :: CPython"
 ]
 
@@ -75,7 +76,7 @@ before-build = "pip install numpy"
 #build-verbosity = 3
 dependency-versions = "latest"
 archs = ["auto64"]
-build = ["cp39-*", "cp310-*", "cp311-*", "cp312-*", "cp313-*"]
+build = ["cp39-*", "cp310-*", "cp311-*", "cp312-*", "cp313-*", "cp314-*"]
 skip = "cp3??t-*"
 test-sources = "tests"
 # - test-sources = "tests" tells cibuildwheel to copy our tests into a temporary directory


### PR DESCRIPTION
This pull request updates the project to support Python 3.14 across the codebase, build system, documentation, and continuous integration workflows. The main changes ensure that Python 3.14 is included wherever supported versions are listed or configured.

**Python 3.14 support**

* Added Python 3.14 to the build matrix in `.github/workflows/tests.yml` and `.github/workflows/wheels.yml`, ensuring CI tests and wheel builds run for Python 3.14. [[1]](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fL15-R15) [[2]](diffhunk://#diff-75627befeafda60a526c116b32f6fdef9bf57bcf456f840d7592c1d6f13facb4L58-R58) [[3]](diffhunk://#diff-75627befeafda60a526c116b32f6fdef9bf57bcf456f840d7592c1d6f13facb4L69-R69)
* Updated the `pyproject.toml` configuration to include Python 3.14 in the `classifiers` list and the `build` matrix for cibuildwheel. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R40) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L78-R79)

**Documentation updates**

* Revised version ranges in `README.rst`, `docs/contributing.rst`, and `docs/install.rst` to indicate support for Python 3.9–3.14. [[1]](diffhunk://#diff-7b3ed02bc73dc06b7db906cf97aa91dec2b2eb21f2d92bc5caa761df5bbc168fL26-R26) [[2]](diffhunk://#diff-e052d37005ef738791e533f325afeb1f194d5d2c18e5cb0cd992ca56097baba0L135-R135) [[3]](diffhunk://#diff-379774f5c6e537f2001c951863c6ac577b56eb5c6e61cc581dce95143760ff36L19-R19)