### PR TITLE
783 add a few more examples working with dicom files

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,5 +43,13 @@ jobs:
         run: |
           python -m pytest tests/
 
+      - name: Download DICOM test resources
+        run: |
+          git clone --depth 1 https://github.com/nbassler/dicomexport.git /tmp/dicomexport
+
+      - name: Run DICOM example script
+        run: |
+          python examples/example03_dicom.py /tmp/dicomexport/res/test_studies/DCPT_headphantom
+
       - name: Build package
         run: python -m build

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-# Created by https://www.toptal.com/developers/gitignore/api/python,visualstudiocode,pycharm
-# Edit at https://www.toptal.com/developers/gitignore?templates=python,visualstudiocode,pycharm
+# Created by https://www.toptal.com/developers/gitignore/api/python,pycharm,visualstudiocode
+# Edit at https://www.toptal.com/developers/gitignore?templates=python,pycharm,visualstudiocode
 
 ### PyCharm ###
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
@@ -305,9 +305,10 @@ pyrightconfig.json
 .history
 .ionide
 
-# End of https://www.toptal.com/developers/gitignore/api/python,visualstudiocode,pycharm
+# End of https://www.toptal.com/developers/gitignore/api/python,pycharm,visualstudiocode
 
 wheelhouse/
 
 # Auto-generated version file
 pytrip/_version.py
+CT.masked.dcm/

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -47,10 +47,10 @@ Most of the lines concern with the setup of TRiP.
 
 
 Example 03 - DICOM import / export
-------------------------
+----------------------------------
 This example demonstrates how to read DICOM CT images and RT Structure Set files into PyTRiP data structures.
 .. literalinclude:: ../examples/example03_dicom.py
     :language: python
     :linenos:
-    :lines: 19-
+    :lines: 1-
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -32,7 +32,8 @@ This example shows how one can select a region inside a CTX data cube using a VD
    :lines: 19-
 
 Working with dose cubes is fully analogous to the CTX cubes.
-	   
+
+
 Example 02 - TRiP execution
 ---------------------------
 
@@ -43,4 +44,13 @@ Most of the lines concern with the setup of TRiP.
    :language: python
    :linenos:
    :lines: 19-
+
+
+Example 03 - DICOM import / export
+------------------------
+This example demonstrates how to read DICOM CT images and RT Structure Set files into PyTRiP data structures.
+.. literalinclude:: ../examples/example03_dicom.py
+    :language: python
+    :linenos:
+    :lines: 19-
 

--- a/examples/example03_dicom.py
+++ b/examples/example03_dicom.py
@@ -73,7 +73,7 @@ def main() -> int:
         help="Path to directory containing DICOM CT and RT Structure Set files"
     )
     args = parser.parse_args()
-    
+
     return process_dicom_study(args.study_path)
 
 

--- a/examples/example03_dicom.py
+++ b/examples/example03_dicom.py
@@ -12,10 +12,9 @@ from pytrip import dicomhelper
 
 def process_dicom_study(study_path: str) -> int:
     """Process and mask a DICOM study based on VOI contours.
-    
+
     Args:
         study_path: Path to directory containing DICOM CT and RT Structure Set files
-        
     Returns:
         Exit code (0 for success)
     """

--- a/examples/example03_dicom.py
+++ b/examples/example03_dicom.py
@@ -53,7 +53,7 @@ def process_dicom_study(study_path: str) -> int:
     # All voxels inside the VOI holds the value 1000, and 0 elsewhere.
     print("get VOI cube")
     voi_cube = voi_body.get_voi_cube()
-    mask = (voi_cube.cube == 1000)
+    mask = voi_cube.cube == 1000
 
     # Set all CT Values inside the BODY VOI to zero HU.
     ctx.cube[mask] = 0

--- a/examples/example03_dicom.py
+++ b/examples/example03_dicom.py
@@ -1,13 +1,28 @@
 import sys
+import argparse
+import os
 from pytrip.ctx import CtxCube
 from pytrip.vdx import VdxCube
 from pytrip import dicomhelper
 
-# point to a directory containing DICOM CT and RT Structure Set files:
-study_path = "/home/bassler/Projects/dicomexport/res/test_studies/DCPT_headphantom"
+# DICOM study example: A test study containing CT and RT Structure Set files
+# can be downloaded from:
+# https://github.com/nbassler/dicomexport/tree/main/res/test_studies/DCPT_headphantom
 
 
-def main(args=None) -> int:
+def process_dicom_study(study_path: str) -> int:
+    """Process and mask a DICOM study based on VOI contours.
+    
+    Args:
+        study_path: Path to directory containing DICOM CT and RT Structure Set files
+        
+    Returns:
+        Exit code (0 for success)
+    """
+    # Check if the directory exists
+    if not os.path.isdir(study_path):
+        print(f"Error: Directory '{study_path}' does not exist.", file=sys.stderr)
+        return 1
 
     # Load DICOM study
     study = dicomhelper.read_dicom_dir(study_path)
@@ -47,6 +62,20 @@ def main(args=None) -> int:
     ctx.write_dicom("CT.masked.dcm")
 
     return 0
+
+
+def main() -> int:
+    """Parse command line arguments and process DICOM study."""
+    parser = argparse.ArgumentParser(
+        description="Process a DICOM study: mask CT values inside VOI contours"
+    )
+    parser.add_argument(
+        "study_path",
+        help="Path to directory containing DICOM CT and RT Structure Set files"
+    )
+    args = parser.parse_args()
+    
+    return process_dicom_study(args.study_path)
 
 
 if __name__ == '__main__':

--- a/examples/example03_dicom.py
+++ b/examples/example03_dicom.py
@@ -1,0 +1,53 @@
+import sys
+from pytrip.ctx import CtxCube
+from pytrip.vdx import VdxCube
+from pytrip import dicomhelper
+
+# point to a directory containing DICOM CT and RT Structure Set files:
+study_path = "/home/bassler/Projects/dicomexport/res/test_studies/DCPT_headphantom"
+
+
+def main(args=None) -> int:
+
+    # Load DICOM study
+    study = dicomhelper.read_dicom_dir(study_path)
+
+    # study is a dict, print all items of the dict
+    for key, value in study.items():
+        print(f"Key: {key}, Type: {type(value)}")
+
+    # Load the CT from the DICOM images
+    ctx = CtxCube()
+    ctx.read_dicom(study)
+
+    print("Show some dimensions of the CT data:")
+    print(ctx.xoffset, ctx.yoffset, ctx.zoffset)
+    print(ctx.dimx, ctx.dimy, ctx.dimz)
+
+    # Load the VOIs from the RT Structure Set
+    vdx = VdxCube(ctx)
+    vdx.read_dicom(study)
+
+    # show all VOI names found in the RTSS
+    print(vdx.voi_names())
+
+    # Get the BODY VOI
+    voi_body = vdx.get_voi_by_name("BODY")
+
+    # Build a DosCube() object based on the VOI.
+    # All voxels inside the VOI holds the value 1000, and 0 elsewhere.
+    print("get VOI cube")
+    voi_cube = voi_body.get_voi_cube()
+    mask = (voi_cube.cube == 1000)
+
+    # Set all CT Values inside the BODY VOI to zero HU.
+    ctx.cube[mask] = 0
+
+    print("Save masked CT as DICOM")
+    ctx.write_dicom("CT.masked.dcm")
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/pytrip/cube.py
+++ b/pytrip/cube.py
@@ -238,8 +238,9 @@ class Cube(object):
         :params [int] indices: tuple or list of integer indices (i,j,k) or [i,j,k]
         :returns: list of positions, including offsets, as a list of floats [x,y,z]
         """
-        pos = [(indices[0] + 0.5) * self.pixel_size + self.xoffset, (indices[1] + 0.5) * self.pixel_size + self.yoffset,
-               self.slice_pos[indices[2]] + self.zoffset]
+        pos = [(indices[0] + 0.5) * self.pixel_size + self.xoffset,
+               (indices[1] + 0.5) * self.pixel_size + self.yoffset,
+               self.slice_pos[indices[2]]]
         logger.debug("Map [i,j,k] {:d} {:d} {:d} to [x,y,z] {:.2f} {:.2f} {:.2f}".format(
             indices[0], indices[1], indices[2], pos[0], pos[1], pos[2]))
         return pos


### PR DESCRIPTION
closes #784 and #785 

This pull request introduces a new example for DICOM import/export, updates the documentation to include this example, and makes several improvements to DICOM handling and related workflows. The most significant changes are the addition of a DICOM example script, enhancements to the test workflow to run this example, and cleanup of DICOM-related code in `pytrip/cube.py`.

**Key changes include:**

### New DICOM Example and Documentation

* Added a new example script `example03_dicom.py` that demonstrates reading DICOM CT and RT Structure Set files, masking CT values inside a VOI, and exporting the result as DICOM. This script can be run standalone and is referenced in the documentation.
* Updated `docs/examples.rst` to document the new DICOM import/export example and include its code.

### CI Workflow Enhancements

* Modified `.github/workflows/tests.yml` to download DICOM test resources and run the new DICOM example script as part of the test workflow, ensuring the example is tested automatically.

### DICOM Handling Improvements in `pytrip/cube.py`

* Cleaned up DICOM import logic by removing compatibility code for old `dicom` package versions, and ensured only `pydicom` is used.
* Fixed a typo in a comment regarding UID generation and improved UID handling for DICOM export.
* Corrected the calculation of physical coordinates in `indices_to_pos` by removing the addition of `zoffset` to the z-coordinate, which now uses only `slice_pos`.
* Removed unnecessary checks for DICOM module loading, since only `pydicom` is now supported. [[1]](diffhunk://#diff-848f934e3d2e23d13f5fff6767dc7f0fc3050c442840ea5f746d2d265dbf8869L820-L821) [[2]](diffhunk://#diff-848f934e3d2e23d13f5fff6767dc7f0fc3050c442840ea5f746d2d265dbf8869L922-L923)
* Updated DICOM export to set the file meta transfer syntax to Explicit VR Little Endian, improving DICOM file compatibility.

### Minor Code and Documentation Cleanups

* Added a missing blank line in `docs/examples.rst` for formatting consistency.
* Added a blank line after the module docstring in `pytrip/cube.py` for PEP8 compliance.